### PR TITLE
WIP: autopilot triumverate + OPS/SPY automation, tests

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -20,5 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install pytest
+          # install the package in editable mode so package imports resolve
+          pip install -e .
       - name: Run tests
         run: pytest -q

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -1,0 +1,24 @@
+name: CI (fast)
+
+on:
+  push:
+    branches: [ main, autopilot/** ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -1,0 +1,36 @@
+name: CI (slow / demo)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  demo-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+          pip install -e .
+      - name: Run K4 demo (smoke)
+        run: |
+          # run a tiny demo to smoke-test the pipeline; limit keeps runtime small
+          python scripts/demo/run_k4_demo.py --limit 5
+      - name: List demo artifacts
+        run: |
+          echo 'Listing artifacts/demo:'
+          ls -la artifacts/demo || true
+      - name: Upload demo artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-artifacts
+          path: artifacts/demo/**

--- a/.github/workflows/demo-smoke.yml
+++ b/.github/workflows/demo-smoke.yml
@@ -1,0 +1,37 @@
+name: Demo smoke
+
+on:
+  push:
+    branches: [ main, autopilot/** ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  demo-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+          pip install -e .
+      - name: Run K4 demo (smoke)
+        run: |
+          # run a tiny demo to smoke-test the pipeline; limit keeps runtime small
+          python scripts/demo/run_k4_demo.py --limit 5
+      - name: List demo artifacts
+        run: |
+          echo 'Listing artifacts/demo:'
+          ls -la artifacts/demo || true
+      - name: Upload demo artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-artifacts
+          path: artifacts/demo/**

--- a/.github/workflows/pr-annotate.yml
+++ b/.github/workflows/pr-annotate.yml
@@ -1,13 +1,28 @@
 name: PR annotate
 
+# Note: to allow commenting/labeling from workflows triggered by PRs (and when using
+# the GITHUB_TOKEN), explicit permissions are required. For PRs from forks, GitHub
+# restricts write operations; consider using pull_request_target for trusted runs.
+permissions:
+  pull-requests: write
+  contents: read
+
 on:
-  pull_request:
+  # use pull_request_target to allow workflows to use repo secrets safely for labeling
+  # and commenting. Be careful: this runs in the target branch context (not the PR ref).
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:
   annotate:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          # fetch the PR ref info but keep working in the target repository context
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Label PR
         uses: actions-ecosystem/action-add-labels@v1
         with:
@@ -25,7 +40,7 @@ jobs:
             If you'd like reviewers requested automatically, set the `REVIEWERS` secret (comma-separated GitHub logins) in the repo settings and this workflow will request them.
 
       - name: Optionally request reviewers
-        if: env.REVIEWERS != ''
+        if: ${{ secrets.REVIEWERS != '' }}
         env:
           REVIEWERS: ${{ secrets.REVIEWERS }}
         run: |

--- a/.github/workflows/pr-annotate.yml
+++ b/.github/workflows/pr-annotate.yml
@@ -1,0 +1,33 @@
+name: PR annotate
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  annotate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            autopilot
+            needs-review
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            Thanks for the PR — automated checks will run (fast smoke + tests).
+            If you'd like reviewers requested automatically, set the `REVIEWERS` secret (comma-separated GitHub logins) in the repo settings and this workflow will request them.
+
+      - name: Optionally request reviewers
+        if: env.REVIEWERS != ''
+        env:
+          REVIEWERS: ${{ secrets.REVIEWERS }}
+        run: |
+          echo "Requesting reviewers: $REVIEWERS"
+          gh pr review --request $REVIEWERS || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,17 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py310-plus"]
+  - repo: local
+    hooks:
+      - id: reflow-md
+        name: Reflow markdown files
+        entry: python
+        args: ["scripts/lint/reflow_md.py"]
+        language: python
+        files: \.(md)$
+      - id: check-md
+        name: Check markdown style
+        entry: python
+        args: ["scripts/lint/check_md.py"]
+        language: python
+        files: \.(md)$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog# CHANGELOG
+
+
+
+## Unreleased## [Unreleased]
+
+
+
+- 2025-10-22: Introduced autopilot flow (Q/OPS/SPY), SPY evaluation harness and conservative extractor, demo smoke CI workflow, and packaging & docs improvements.- Pending: route scoring refinement, multiprocessing, advanced Hill assemblies.
+
+
+## [2025-10-20] Adaptive & Route Expansion
+
+- Added adaptive fusion weighting (wordlist_hit_rate + trigram_entropy heuristics).
+- Added route transposition stage (spiral, boustrophedon, diagonal traversals).
+- Implemented multi-crib positional transposition stage.
+- Added 3x3 Hill key pruning (partial score).
+- Added attempt logging & persistence for Hill, Clock, Transposition.
+- Added advanced linguistic metrics (wordlist hit rate, trigram entropy, bigram gap variance).
+- Added normalization safeguards (equal-score midpoint) & adaptive diagnostics.
+- Corrected crib indices (EAST 22, NORTHEAST 25, BERLIN 64, CLOCK 69).
+
+## [Earlier] Pre-adaptive foundation
+
+- Core multi-stage pipeline (Hill, transposition, adaptive transposition, masking, Berlin Clock).
+- Weighted multi-stage fusion & candidate artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 
 
-- 2025-10-22: Introduced autopilot flow (Q/OPS/SPY), SPY evaluation harness and conservative extractor, demo smoke CI workflow, and packaging & docs improvements.- Pending: route scoring refinement, multiprocessing, advanced Hill assemblies.
+- 2025-10-22: Introduced autopilot flow (Q/OPS/SPY), SPY evaluation harness and conservative
+extractor, demo smoke CI workflow, and packaging & docs improvements.- Pending: route scoring
+refinement, multiprocessing, advanced Hill assemblies.
 
 
 ## [2025-10-20] Adaptive & Route Expansion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,18 +81,18 @@ print("Attempt log written:", path)
 
 ## Workflow
 
-1. Fork and branch from `main`.
-2. Implement a focused enhancement (small, testable functions).
-3. Add or update tests under `tests/` (avoid large exhaustive brute-force loops; cap iterations).
-4. Update exports in `src/k4/__init__.py` if you introduce new public symbols.
-5. Update `roadmap.md` only if you add or refine planned analytical directions.
-6. Run `python -m unittest discover -s tests` and ensure all tests pass.
-7. Submit a PR with a concise description of rationale and methodology.
+1. Fork and branch from `main`. 2. Implement a focused enhancement (small, testable functions). 3.
+Add or update tests under `tests/` (avoid large exhaustive brute-force loops; cap iterations). 4.
+Update exports in `src/k4/__init__.py` if you introduce new public symbols. 5. Update `roadmap.md`
+only if you add or refine planned analytical directions. 6. Run `python -m unittest discover -s
+tests` and ensure all tests pass. 7. Submit a PR with a concise description of rationale and
+methodology.
 
 ## Code Guidelines
 
 - Prefer pure functions over hidden state.
-- Use explicit module-level caches (e.g., `_cache_holder`) rather than globals sprinkled across functions.
+- Use explicit module-level caches (e.g., `_cache_holder`) rather than globals sprinkled across
+functions.
 - Keep scoring and search logic separate; scoring modules should not mutate state.
 - Group related exports logically; avoid re-exporting internal helpers unnecessarily.
 - Name stages clearly: `make_<purpose>_stage()`.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Detailed future plans (candidate reporting, Berlin Clock expansion, pruning heur
 
 See full document in `docs/K4_STRATEGY.md` – includes current completion status and next actions.
 
+## Recent changes
+
+- 2025-10-22: Added offline autopilot flow (Q/OPS/SPY), conservative SPY extractor with evaluation harness, demo smoke CI and packaging improvements. See `docs/AUTOPILOT.md` for details.
+
 ## Contributing
 
 Contribution guidelines moved to `CONTRIBUTING.md` → [Contributing Guide](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,43 +1,70 @@
 # KRYPTOS
 
-Inspired by *The Unexplained* with William Shatner, I set out to solve Kryptos using Python! This project focuses on implementing cryptographic techniques, specifically the Vigenère cipher and structural transposition analysis, to decrypt the famous Kryptos sculpture.
+Inspired by *The Unexplained* with William Shatner, I set out to solve Kryptos using Python! This
+project focuses on implementing cryptographic techniques, specifically the Vigenère cipher and
+structural transposition analysis, to decrypt the famous Kryptos sculpture.
 
 ## TL;DR
 
-This Kryptos repository is a research toolkit for exploring layered cipher hypotheses (Vigenère, Hill, transposition, masking, and related hybrids) with an emphasis on reproducible pipelines and scoring heuristics.
+This Kryptos repository is a research toolkit for exploring layered cipher hypotheses (Vigenère,
+Hill, transposition, masking, and related hybrids) with an emphasis on reproducible pipelines and
+scoring heuristics.
 
-**K4 is the last unsolved piece of a CIA sculpture puzzle.** Imagine a secret message carved in copper that nobody has cracked in 30+ years. We're using Python to systematically try every reasonable decryption method – techniques that cryptanalysts may have attempted manually but couldn't exhaustively explore. Our approach combines automated testing with intelligent scoring to measure how "English-like" each result appears:
+Related documents / quick links:
 
-1. **Hill Cipher** - Matrix-based substitution where letters become numbers, transform through matrix multiplication, then convert back
-2. **Transposition** - Systematic letter rearrangement (write in columns, read in rows, or more complex patterns)
-3. **Masking** - Identifying and removing dummy letters that serve as padding or obfuscation
-4. **Berlin Clock** - Using the iconic clock's binary time pattern as a cryptographic key
-5. **Combo Attacks** - Chaining multiple methods together (K4 likely uses 2-3 techniques layered in sequence)
+- Core docs: `docs/README_CORE.md`
+- K4 strategy: `docs/K4_STRATEGY.md`
+- Autopilot: `docs/AUTOPILOT.md`
+- Plan: `docs/PLAN.md`
+- Roadmap: `ROADMAP.md`
 
-We evaluate candidates using linguistic patterns – common letter pairs, trigram frequencies, real word detection – to identify promising decryptions. Think of it as trying thousands of lock combinations, but guided by cryptanalytic intuition rather than brute force. After all, humans design puzzles with intention, not randomness!
+**K4 is the last unsolved piece of a CIA sculpture puzzle.** Imagine a secret message carved in
+copper that nobody has cracked in 30+ years. We're using Python to systematically try every
+reasonable decryption method – techniques that cryptanalysts may have attempted manually but
+couldn't exhaustively explore. Our approach combines automated testing with intelligent scoring to
+measure how "English-like" each result appears:
+
+1. **Hill Cipher** - Matrix-based substitution where letters become numbers, transform through
+matrix multiplication, then convert back 2. **Transposition** - Systematic letter rearrangement
+(write in columns, read in rows, or more complex patterns) 3. **Masking** - Identifying and removing
+dummy letters that serve as padding or obfuscation 4. **Berlin Clock** - Using the iconic clock's
+binary time pattern as a cryptographic key 5. **Combo Attacks** - Chaining multiple methods together
+(K4 likely uses 2-3 techniques layered in sequence)
+
+We evaluate candidates using linguistic patterns – common letter pairs, trigram frequencies, real
+word detection – to identify promising decryptions. Think of it as trying thousands of lock
+combinations, but guided by cryptanalytic intuition rather than brute force. After all, humans
+design puzzles with intention, not randomness!
 
 ## Current Progress
 
 ### ✅ K1: "Between subtle shading and the absence of light lies the nuance of iqlusion"
 
 - **Status**: Solved.
-- **Details**: Decrypted via Vigenère using keyed alphabet `KRYPTOSABCDEFGHIJLMNQUVWXZ`. Intentional misspelling preserved: `IQLUSION`.
+- **Details**: Decrypted via Vigenère using keyed alphabet `KRYPTOSABCDEFGHIJLMNQUVWXZ`. Intentional
+misspelling preserved: `IQLUSION`.
 
 ### ✅ K2: "It was totally invisible. How's that possible?"
 
 - **Status**: Solved.
-- **Details**: Vigenère (key: `ABSCISSA`). Includes embedded null/structural padding (`S`) for historical alignment. Contains geospatial coordinates and narrative text.
+- **Details**: Vigenère (key: `ABSCISSA`). Includes embedded null/structural padding (`S`) for
+historical alignment. Contains geospatial coordinates and narrative text.
 
 ### ✅ K3: "Slowly, desperately slowly, the remains of passage debris..."
 
 - **Status**: Solved (double rotational transposition method).
-- **Details**: Implemented the documented 24×14 grid → 90° rotation → reshape to 8-column grid → second 90° rotation. Resulting plaintext matches known solution including deliberate misspelling `DESPARATLY` (analogous to `IQLUSION` in K1).
+- **Details**: Implemented the documented 24×14 grid → 90° rotation → reshape to 8-column grid →
+second 90° rotation. Resulting plaintext matches known solution including deliberate misspelling
+`DESPARATLY` (analogous to `IQLUSION` in K1).
 
 ### ℹ️ K4: The unsolved mystery
 
 - **Status**: Unsolved.
-- **Implemented Toolkit**: See K4 modules below (Hill cipher exploration, scoring, constraint pipeline, multi-stage fusion).
-- **Latest Additions**: Multi-crib positional transposition stage, attempt logging & persistence, advanced linguistic metrics, 3x3 Hill key pruning (partial_len/partial_min tunable in hill constraint stage).
+- **Implemented Toolkit**: See K4 modules below (Hill cipher exploration, scoring, constraint
+pipeline, multi-stage fusion).
+- **Latest Additions**: Multi-crib positional transposition stage, attempt logging & persistence,
+advanced linguistic metrics, 3x3 Hill key pruning (partial_len/partial_min tunable in hill
+constraint stage).
 
 ## Deliberate Misspellings / Anomalies
 
@@ -48,7 +75,9 @@ We evaluate candidates using linguistic patterns – common letter pairs, trigra
 
 ### K2 Structural Padding
 
-K2 contains systematic X (and some Y) insertions serving as alignment/null separators rather than mistakes. They should be treated as structural artifacts when analyzing pattern continuity or constructing transposition hypotheses.
+K2 contains systematic X (and some Y) insertions serving as alignment/null separators rather than
+mistakes. They should be treated as structural artifacts when analyzing pattern continuity or
+constructing transposition hypotheses.
 
 ## Features
 
@@ -74,23 +103,37 @@ K2 contains systematic X (and some Y) insertions serving as alignment/null separ
 - **Transformation trace & lineage** (each candidate records stage + transformation chain) ([learn more](https://en.wikipedia.org/wiki/Reproducibility))
 - **Attempt logging & persistence** (Hill, Clock, Transposition permutations → timestamped JSON) ([learn more](https://en.wikipedia.org/wiki/Logging))
 - **Candidate reporting artifacts** (JSON + optional CSV summaries) ([learn more](https://en.wikipedia.org/wiki/Reproducibility))
-- **Adaptive fusion weighting** (optional `adaptive=True` in composite run) leveraging wordlist hit rate & trigram entropy heuristics.
+- **Adaptive fusion weighting** (optional `adaptive=True` in composite run) leveraging wordlist hit
+rate & trigram entropy heuristics.
 
 ## K4 Analysis Toolkit (New / Updated Modules)
 
 Located under `src/k4/`:
 
-Details and module-level examples for K4 have been moved to `docs/K4_STRATEGY.md` (K4-specific notes) and `docs/README_CORE.md` (code-level examples).
+Details and module-level examples for K4 have been moved to `docs/K4_STRATEGY.md` (K4-specific
+notes) and `docs/README_CORE.md` (code-level examples).
 
 ## Roadmap
 
-Detailed future plans (candidate reporting, Berlin Clock expansion, pruning heuristics, extended Hill search, masking strategies) have moved to `ROADMAP.md` → see the full document here: [Roadmap Guide](./ROADMAP.md).
+Detailed future plans (candidate reporting, Berlin Clock expansion, pruning heuristics, extended
+Hill search, masking strategies) have moved to `ROADMAP.md` → see the full document here: [Roadmap
+Guide](./ROADMAP.md).
 
 See full document in `docs/K4_STRATEGY.md` – includes current completion status and next actions.
 
 ## Recent changes
 
-- 2025-10-22: Added offline autopilot flow (Q/OPS/SPY), conservative SPY extractor with evaluation harness, demo smoke CI and packaging improvements. See `docs/AUTOPILOT.md` for details.
+- 2025-10-22: Added offline autopilot flow (Q/OPS/SPY), conservative SPY extractor with evaluation
+harness, demo smoke CI and packaging improvements. See `docs/AUTOPILOT.md` for details.
+
+Autopilot (Q / OPS / SPY) summary
+
+The repository includes an offline autopilot flow (Q / OPS / SPY) to recommend and execute safe
+tuning and extraction steps. `ask_triumverate.py` implements a lightweight driver that can run a
+deterministic OPS tuning sweep and then invoke the conservative SPY extractor. If `SPY_MIN_CONF` is
+not set, the autopilot will compute a conservative threshold using the evaluation harness; it falls
+back to `0.25` when no labeled runs are available. See `docs/AUTOPILOT.md` for full details and CLI
+examples.
 
 ## Contributing
 
@@ -102,7 +145,8 @@ Use `baseline_stats(text)` to inspect metrics including advanced linguistic feat
 
 ## Data Sources
 
-Frequency & n-gram data in `data/` (TSV). High-quality quadgrams loaded automatically if `quadgrams_high_quality.tsv` exists. Fallback unigram distribution used if files absent.
+Frequency & n-gram data in `data/` (TSV). High-quality quadgrams loaded automatically if
+`quadgrams_high_quality.tsv` exists. Fallback unigram distribution used if files absent.
 
 ## License
 
@@ -113,7 +157,8 @@ See `LICENSE`.
 - `docs/README_CORE.md` — project reference and examples
 - `docs/K4_STRATEGY.md` — K4-specific strategy and notes
 
-If you prefer to run an example pipeline, see `scripts/tools/run_pipeline_sample.py` for a minimal programmatic example.
+If you prefer to run an example pipeline, see `scripts/tools/run_pipeline_sample.py` for a minimal
+programmatic example.
 
 ## References & Research
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,15 @@ Detailed plan for advancing Kryptos K4 analysis.
 
 ## High-Level Planned Modules / Enhancements
 
+- Short term (0-7 days):
+ - Harden autopilot (OPS/ SPY / Q) with conservative defaults and evaluation-driven thresholds.
+ - Add tiny tuning sweep and demo pipelines; wire to artifacts/ for traceability.
+ - Improve test coverage around scoring and transposition components.
+Short term (0-7 days):
+- Harden autopilot (OPS/ SPY / Q) with conservative defaults and evaluation-driven thresholds.
+- Add tiny tuning sweep and demo pipelines; wire to artifacts/ for traceability.
+- Improve test coverage around scoring and transposition components.
+
 - Layered / composite transposition + substitution search pruning. (IN PROGRESS: basic columnar partial-score pruning added)
 - Expanded Berlin Clock enumeration (full lamp state/time modeling, parity & quarter markers). (PARTIALLY IMPLEMENTED: full lamp state & enumeration utilities; pipeline stage added `make_berlin_clock_stage`)
 - Recursive masking / null removal heuristics. (PENDING)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,34 @@
 # K4 Roadmap
 
 Detailed plan for advancing Kryptos K4 analysis.
+## Roadmap Guidelines
+
+High-level milestones for the next phases. This is intentionally short and actionable.
+
+1. Stabilize core scoring & transposition tests
+   - Add focused unit tests for `src/k4/scoring.py` and `src/k4/transposition.py`.
+   - Acceptance: tests green and file coverage targets met (scoring >=95%, transposition >=90%).
+
+2. Tuning harness and deterministic sweeps
+   - Wire and validate a tiny deterministic tuning sweep harness
+     (`scripts/tuning/crib_weight_sweep.py`).
+   - Acceptance: reproducible CSV artifacts in `artifacts/tuning_runs/` for small grids.
+
+3. Autopilot & SPY integration
+   - Ensure `scripts/dev/ask_triumverate.py` computes or uses a conservative SPY `min_conf` and that
+     `scripts/dev/spy_extractor.py` writes curated hints to `agents/LEARNED.md`.
+
+4. Demos, CI and reproducibility
+   - Add demo runner artifacts and CI steps to validate example runs produce expected artifact
+     shapes.
+
+5. Long-run automation
+   - Implement the long-loop daemon/runner to rotate parameter sets and retain run history.
+
+### Notes
+
+- Keep changes small and test-driven. Each milestone should have a clear acceptance criterion and a
+smoke test.
 
 ## High-Level Planned Modules / Enhancements
 
@@ -13,17 +41,23 @@ Short term (0-7 days):
 - Add tiny tuning sweep and demo pipelines; wire to artifacts/ for traceability.
 - Improve test coverage around scoring and transposition components.
 
-- Layered / composite transposition + substitution search pruning. (IN PROGRESS: basic columnar partial-score pruning added)
-- Expanded Berlin Clock enumeration (full lamp state/time modeling, parity & quarter markers). (PARTIALLY IMPLEMENTED: full lamp state & enumeration utilities; pipeline stage added `make_berlin_clock_stage`)
+- Layered / composite transposition + substitution search pruning. (IN PROGRESS: basic columnar
+partial-score pruning added)
+- Expanded Berlin Clock enumeration (full lamp state/time modeling, parity & quarter markers).
+(PARTIALLY IMPLEMENTED: full lamp state & enumeration utilities; pipeline stage added
+`make_berlin_clock_stage`)
 - Recursive masking / null removal heuristics. (PENDING)
 - Probable word placement scoring (additional cribs beyond BERLIN/CLOCK/EASTNORTHEAST). (PENDING)
-- Composite reporting (persist top-N candidate plaintexts & metrics to JSON/CSV). (IMPLEMENTED: reporting.py JSON/CSV artifacts)
-- Extended Hill cipher exploration (3x3 & larger constrained key search under crib anchors). (PARTIAL: 3x3 ops present, constraint search still 2x2)
+- Composite reporting (persist top-N candidate plaintexts & metrics to JSON/CSV). (IMPLEMENTED:
+reporting.py JSON/CSV artifacts)
+- Extended Hill cipher exploration (3x3 & larger constrained key search under crib anchors).
+(PARTIAL: 3x3 ops present, constraint search still 2x2)
 - Overlay & spiral path grid traversal experiments. (PENDING)
 
 ## Candidate Reporting (Status: IMPLEMENTED)
 
-A forthcoming pipeline reporting stage will persist ranked candidates (key/source metadata + metrics). JSON schema example:
+A forthcoming pipeline reporting stage will persist ranked candidates (key/source metadata +
+metrics). JSON schema example:
 
 ```json
 {
@@ -53,23 +87,27 @@ A forthcoming pipeline reporting stage will persist ranked candidates (key/sourc
 
 ## Berlin Clock Enumeration (Status: PARTIAL)
 
-Current simplified shift vector expanded with full lamp modeling & enumeration functions (`full_clock_state`, `full_berlin_clock_shifts`, `enumerate_clock_shift_sequences`). Next: integrate as pipeline stage with scoring comparison.
+Current simplified shift vector expanded with full lamp modeling & enumeration functions
+(`full_clock_state`, `full_berlin_clock_shifts`, `enumerate_clock_shift_sequences`). Next: integrate
+as pipeline stage with scoring comparison.
 
 ## Transposition Pruning Heuristics (Status: INITIAL)
 
-Added optional partial segment scoring (parameters: prune, partial_length, partial_min_score) to skip low-quality permutations early. Future: adaptive sampling & prefix caching.
+Added optional partial segment scoring (parameters: prune, partial_length, partial_min_score) to
+skip low-quality permutations early. Future: adaptive sampling & prefix caching.
 
 ## Search Strategy Evolution
 
-1. Establish baseline brute-force (done).
-2. Introduce heuristic pruning.
-3. Add multi-stage composite pipeline (transposition → substitution → shift overlay → scoring).
-4. Integrate Berlin Clock enumeration as an optional stage.
-5. Add persistence/reporting and comparative metrics tracking.
+1. Establish baseline brute-force (done). 2. Introduce heuristic pruning. 3. Add multi-stage
+composite pipeline (transposition → substitution → shift overlay → scoring). 4. Integrate Berlin
+Clock enumeration as an optional stage. 5. Add persistence/reporting and comparative metrics
+tracking.
 
 ## Metrics Expansion (Status: PARTIAL)
 
-Positional crib weighting implemented (`positional_crib_bonus`, `combined_plaintext_score_with_positions`). Quadgram support added (`quadgram_score`). Future metrics: spacing analysis, entropy refinement.
+Positional crib weighting implemented (`positional_crib_bonus`,
+`combined_plaintext_score_with_positions`). Quadgram support added (`quadgram_score`). Future
+metrics: spacing analysis, entropy refinement.
 
 ## Status Tracking
 
@@ -78,15 +116,16 @@ Use issues to map each bullet to deliverables; close with test evidence and READ
 ## Baseline Section Anomalies Reference
 
 - K1: Deliberate misspelling `IQLUSION` retained.
-- K2: No deliberate spelling anomalies; apparent `X` characters in historic presentations function as separators/padding, not errors.
+- K2: No deliberate spelling anomalies; apparent `X` characters in historic presentations function
+as separators/padding, not errors.
 - K3: Deliberate misspelling `DESPARATLY` retained.
 
----
-Completed (2025-10-21):
+--- Completed (2025-10-21):
 
 - Extended plaintext scoring (berlin_clock_pattern_validator, pattern bonus integration).
 - Pipeline executor with candidate pruning & artifact logging (attempt_log.jsonl + summary.json).
-- Automated spacing / lint autofix tooling (pep8_spacing_autofix.py) for consistent style compliance.
+- Automated spacing / lint autofix tooling (pep8_spacing_autofix.py) for consistent style
+compliance.
 - Pruning logic & pattern bonus tests (test_executor_pruning_and_pattern.py).
 - Minimal runnable sample script (scripts/tools/run_pipeline_sample.py).
 
@@ -98,6 +137,7 @@ Next Iteration Targets:
 - Adaptive gating refinement (dynamic threshold adjustment based on previous stage score deltas).
 - Caching of expensive permutation searches (persistent prefix/permutation caches across runs).
 - Integration test chaining multiple transposition + masking stages.
-- Berlin Clock deep pattern alignment scoring (lamp temporal sequencing bonuses beyond ordering stub).
+- Berlin Clock deep pattern alignment scoring (lamp temporal sequencing bonuses beyond ordering
+stub).
 
 Last updated: 2025-10-21

--- a/docs/10KFT.md
+++ b/docs/10KFT.md
@@ -1,0 +1,116 @@
+# Project index (10k ft view)
+
+This file gives a very short, high-level overview of the repository by top-level directories and the
+core Python scripts you will likely use. Each entry has an ELI5 sentence describing what it does.
+
+## Top-level directories
+
+- `kryptos/` — Main Python package and core logic.
+  - `src/` — Python package source. Contains the core implementation (k4 executor, agents, and
+    utilities).
+  - `scripts/` — Development and tooling scripts (orchestration, extractors, tuning harnesses).
+  - `tests/` — Unit and integration tests covering the core behaviors.
+  - `docs/` — Project documentation (this file and other guides).
+
+- `scripts/` — Repo-level helper scripts (linting, demos, tuning runners). These are convenience
+scripts to run common tasks outside the package.
+
+- `artifacts/` — Generated outputs from runs and demos (CSV, JSON, run folders). Useful for
+experiment traces and reproducible results.
+
+- `examples/` — Small example programs that show how to wire the package for quick experiments.
+
+## Core python scripts (ELI5)
+
+- `kryptos/src/k4/executor.py` — Runs job variants in parallel and collects results. ELI5: "It tries
+different ways to run a job at once and picks the outputs when they finish."
+
+- `kryptos/scripts/dev/orchestrator.py` — Orchestrates OPS (tuning) runs and stores run metadata.
+ELI5: "It runs tuning experiments and remembers what happened so we can learn from it."
+
+- `scripts/dev/ask_triumverate.py` — High-level autopilot driver that runs OPS then SPY extraction.
+ELI5: "A small orchestrator that asks the 3 helpers (Q/OPS/SPY) to make recommendations and
+optionally write learned hints."
+
+- `scripts/dev/spy_extractor.py` — Conservative extractor that scans run artifacts for crib-like
+tokens and writes `agents/LEARNED.md`. ELI5: "It looks for useful little hints in a run and notes
+them down if they look confident."
+
+- `kryptos/scripts/tuning/spy_eval.py` — Evaluates different SPY thresholds using labeled runs and
+chooses a conservative threshold (precision-first). ELI5: "It tests how picky the extractor should
+be so we trust what it finds."
+
+- `scripts/tuning/crib_weight_sweep.py` — OPS tuning harness that sweeps crib weight parameters and
+logs results. ELI5: "It tries different weights for crib signals to see which makes the system
+perform better."
+
+- `scripts/demo/run_k4_demo.py` — A small demo runner that executes the k4 pipeline and saves
+artifacts for review. ELI5: "Runs a demo job and stores its outputs so you can inspect how the
+system behaved."
+
+- `scripts/lint/run_lint.ps1` — Repo lint runner that invokes ruff/flake8/pylint and simple markdown
+checks. ELI5: "One script to check the code and docs for style and common problems."
+
+- `scripts/lint/check_md.py` and `scripts/lint/reflow_md.py` — Lightweight markdown checks and
+reflow utility. ELI5: "Helps keep documentation lines tidy and flags basic markdown issues."
+
+## Where to start (practical tips)
+
+- To run tests: run the project's test command (pytest) from the repo root.
+- To run the autopilot demo: run `scripts/dev/ask_triumverate.py` (it will call OPS and optionally
+SPY extractor).
+- To tune SPY thresholds: use `kryptos/scripts/tuning/spy_eval.py` against labeled runs in
+`artifacts/`.
+- For quick code/style checks: run `./scripts/lint/run_lint.ps1` from the repo root (PowerShell).
+
+## Notes
+
+- This index is intentionally brief. See individual files and `docs/AUTOPILOT.md` for more detail
+when needed.
+- If something seems missing, search for `_run_`, `tuning`, `spy`, or `orchestrator` in the repo to
+find related scripts.
+
+## Flow and design (high level)
+
+This section briefly explains how the main pieces coordinate during a typical autopilot/tuning run.
+It's intentionally compact — think sequence steps rather than full design docs.
+
+1. Orchestrator kicks off an OPS tuning run
+
+- `kryptos/scripts/dev/orchestrator.py` prepares a run, records metadata (e.g., `max_delta`) and
+calls OPS tuning routines.
+- OPS tuning scripts (e.g., `scripts/tuning/crib_weight_sweep.py`) sweep parameters and write
+artifacts under `artifacts/`.
+
+1. Executor runs job variants
+
+- `kryptos/src/k4/executor.py` executes multiple job variants in parallel and collects results;
+tuning uses these results to score parameter combinations.
+
+1. SPY extraction and evaluation
+
+- `scripts/dev/spy_extractor.py` scans run artifacts for crib-like tokens and appends confident
+findings to `agents/LEARNED.md`.
+- `kryptos/scripts/tuning/spy_eval.py` evaluates extractor thresholds against labeled runs and
+recommends a conservative `min_conf` (precision-first).
+
+1. Autopilot driver ties them together
+
+- `scripts/dev/ask_triumverate.py` is the high-level driver: it runs OPS tuning, obtains
+`max_delta`/run metadata, computes or asks the SPY evaluator for a `min_conf`, then runs the SPY
+extractor to record learned hints.
+
+1. Demos and experiments
+
+- `scripts/demo/run_k4_demo.py` or examples under `examples/` run the pipeline end-to-end to produce
+reproducible `artifacts/` for inspection and evaluation.
+
+Design notes (TL;DR)
+
+- Separation of concerns: `src/` contains the runtime logic (executor, core algorithms),
+`kryptos/scripts/` contains evaluation/tuning helpers, and `scripts/` contains repo-level tooling
+(lint, demos, extractors).
+- Conservative defaults: SPY extraction favors precision over recall; the eval harness picks
+thresholds to avoid noisy learned hints.
+- Reproducibility: tuning scripts write structured artifacts so the evaluator and extractor operate
+on recorded runs.

--- a/docs/AUTOPILOT.md
+++ b/docs/AUTOPILOT.md
@@ -1,28 +1,75 @@
 # Autopilot, SPY Tuning, and OPS Overview
 
-This document summarizes the offline autopilot flow (Q / OPS / SPY), the conservative
-SPY extractor, the SPY evaluation harness, and CI demo wiring added to the project.
+This document summarizes the offline autopilot flow (Q / OPS / SPY), the conservative SPY extractor,
+the SPY evaluation harness, and CI demo wiring added to the project.
+
+Related documents / breadcrumbs:
+
+- Project core: `README_CORE.md`
+- K4 strategy: `K4_STRATEGY.md`
+- Plan: `PLAN.md`
+- Roadmap: `../ROADMAP.md`
 
 ## Components
 
-- Q (Planner): produces a short plan or single-line recommended next action. Implemented in `scripts/dev/ask_triumverate.py` and helpers.
-- OPS (Operational Tuner): runs tuning sweeps to measure sensitivity to crib weights and other parameters. Key scripts: `scripts/tuning/crib_weight_sweep.py`, `scripts/tuning/tiny_tuning_sweep.py`.
-- SPY (Conservative Extractor): scans tuning run CSV artifacts and extracts high-confidence quoted tokens present in `docs/sources/sanborn_crib_candidates.txt`. Implemented in `scripts/dev/spy_extractor.py`.
+- Q (Planner): produces a short plan or single-line recommended next action. Implemented in
+  `scripts/dev/ask_triumverate.py` and helpers.
+- OPS (Operational Tuner): runs tuning sweeps to measure sensitivity to crib weights and other
+  parameters. Key scripts: `scripts/tuning/crib_weight_sweep.py`,
+  `scripts/tuning/tiny_tuning_sweep.py`.
+- SPY (Conservative Extractor): scans tuning run CSV artifacts and extracts high-confidence quoted
+  tokens present in `docs/sources/sanborn_crib_candidates.txt`. Implemented in
+  `scripts/dev/spy_extractor.py`.
 
 ## SPY threshold selection
 
 - The SPY extractor accepts a minimum confidence via `SPY_MIN_CONF` env var or `--min-conf` CLI.
-- If unset, the autopilot will call `kryptos.scripts.tuning.spy_eval.select_best_threshold` which evaluates precision/recall/F1 across thresholds and now *prefers precision* (conservative extraction). Tie-breaker is F1.
+- If unset, the autopilot will call `kryptos.scripts.tuning.spy_eval.select_best_threshold` which
+  evaluates precision/recall/F1 across thresholds and now *prefers precision* (conservative
+  extraction). Tie-breaker is F1.
+
+Notes and defaults:
+
+- If `SPY_MIN_CONF` is not set and `select_best_threshold` cannot determine a threshold (no labels
+  or runs available), the autopilot will fall back to a conservative default of `0.25`.
+- The SPY extractor computes a per-token confidence as `delta / max_delta` where `delta` is the run-
+  specific match delta and `max_delta` is the maximum delta observed in that run's scan. The `--min-
+  conf` threshold is applied to that normalized confidence to decide which tokens to emit.
+
+Example: evaluating thresholds
+
+You can evaluate thresholds locally using the `spy_eval` harness. For example, to print
+precision/recall/F1 for common thresholds:
+
+```powershell
+python -c "from scripts.tuning import spy_eval; print(spy_eval.evaluate('data/spy_eval_labels.csv',
+ 'artifacts/tuning_runs'))"
+```
+
+Or programmatically select the best threshold (precision-first) and print it:
+
+```python
+from pathlib import Path
+from scripts.tuning import spy_eval
+
+labels = Path('data/spy_eval_labels.csv')
+runs = Path('artifacts/tuning_runs')
+best = spy_eval.select_best_threshold(labels, runs)
+print('Best threshold:', best)
+```
 
 ## Artifacts
 
-- Tuning runs: `artifacts/tuning_runs/run_<timestamp>/` containing `crib_weight_sweep.csv` and `weight_*_details.csv`.
+- Tuning runs: `artifacts/tuning_runs/run_<timestamp>/` containing `crib_weight_sweep.csv` and
+  `weight_*_details.csv`.
 - Demo runs: `artifacts/demo/run_<timestamp>/` produced by `scripts/demo/run_k4_demo.py`.
 
 ## CI
 
-- Fast CI (`.github/workflows/ci-fast.yml`) runs tests quickly and installs the package in editable mode.
-- Slow CI (`.github/workflows/ci-slow.yml`) runs the K4 demo smoke test and uploads artifacts for debugging; it runs on pushes to `main` and manual dispatch.
+- Fast CI (`.github/workflows/ci-fast.yml`) runs tests quickly and installs the package in editable
+  mode.
+- Slow CI (`.github/workflows/ci-slow.yml`) runs the K4 demo smoke test and uploads artifacts for
+  debugging; it runs on pushes to `main` and manual dispatch.
 
 ## How to run locally
 
@@ -34,13 +81,13 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
-2. Run the autopilot in dry-run:
+1. Run the autopilot in dry-run:
 
 ```powershell
 python scripts/dev/ask_triumverate.py --dry-run
 ```
 
-3. Run the demo:
+1. Run the demo:
 
 ```powershell
 python scripts/demo/run_k4_demo.py --limit 5

--- a/docs/AUTOPILOT.md
+++ b/docs/AUTOPILOT.md
@@ -1,0 +1,47 @@
+# Autopilot, SPY Tuning, and OPS Overview
+
+This document summarizes the offline autopilot flow (Q / OPS / SPY), the conservative
+SPY extractor, the SPY evaluation harness, and CI demo wiring added to the project.
+
+## Components
+
+- Q (Planner): produces a short plan or single-line recommended next action. Implemented in `scripts/dev/ask_triumverate.py` and helpers.
+- OPS (Operational Tuner): runs tuning sweeps to measure sensitivity to crib weights and other parameters. Key scripts: `scripts/tuning/crib_weight_sweep.py`, `scripts/tuning/tiny_tuning_sweep.py`.
+- SPY (Conservative Extractor): scans tuning run CSV artifacts and extracts high-confidence quoted tokens present in `docs/sources/sanborn_crib_candidates.txt`. Implemented in `scripts/dev/spy_extractor.py`.
+
+## SPY threshold selection
+
+- The SPY extractor accepts a minimum confidence via `SPY_MIN_CONF` env var or `--min-conf` CLI.
+- If unset, the autopilot will call `kryptos.scripts.tuning.spy_eval.select_best_threshold` which evaluates precision/recall/F1 across thresholds and now *prefers precision* (conservative extraction). Tie-breaker is F1.
+
+## Artifacts
+
+- Tuning runs: `artifacts/tuning_runs/run_<timestamp>/` containing `crib_weight_sweep.csv` and `weight_*_details.csv`.
+- Demo runs: `artifacts/demo/run_<timestamp>/` produced by `scripts/demo/run_k4_demo.py`.
+
+## CI
+
+- Fast CI (`.github/workflows/ci-fast.yml`) runs tests quickly and installs the package in editable mode.
+- Slow CI (`.github/workflows/ci-slow.yml`) runs the K4 demo smoke test and uploads artifacts for debugging; it runs on pushes to `main` and manual dispatch.
+
+## How to run locally
+
+1. Install dev dependencies and the package in editable mode:
+
+```powershell
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install -e .
+```
+
+2. Run the autopilot in dry-run:
+
+```powershell
+python scripts/dev/ask_triumverate.py --dry-run
+```
+
+3. Run the demo:
+
+```powershell
+python scripts/demo/run_k4_demo.py --limit 5
+```

--- a/docs/AUTOPILOT.md
+++ b/docs/AUTOPILOT.md
@@ -13,28 +13,28 @@ Related documents / breadcrumbs:
 ## Components
 
 - Q (Planner): produces a short plan or single-line recommended next action. Implemented in
-  `scripts/dev/ask_triumverate.py` and helpers.
+`scripts/dev/ask_triumverate.py` and helpers.
 - OPS (Operational Tuner): runs tuning sweeps to measure sensitivity to crib weights and other
-  parameters. Key scripts: `scripts/tuning/crib_weight_sweep.py`,
-  `scripts/tuning/tiny_tuning_sweep.py`.
+parameters. Key scripts: `scripts/tuning/crib_weight_sweep.py`,
+`scripts/tuning/tiny_tuning_sweep.py`.
 - SPY (Conservative Extractor): scans tuning run CSV artifacts and extracts high-confidence quoted
-  tokens present in `docs/sources/sanborn_crib_candidates.txt`. Implemented in
-  `scripts/dev/spy_extractor.py`.
+tokens present in `docs/sources/sanborn_crib_candidates.txt`. Implemented in
+`scripts/dev/spy_extractor.py`.
 
 ## SPY threshold selection
 
 - The SPY extractor accepts a minimum confidence via `SPY_MIN_CONF` env var or `--min-conf` CLI.
 - If unset, the autopilot will call `kryptos.scripts.tuning.spy_eval.select_best_threshold` which
-  evaluates precision/recall/F1 across thresholds and now *prefers precision* (conservative
-  extraction). Tie-breaker is F1.
+evaluates precision/recall/F1 across thresholds and now *prefers precision* (conservative
+extraction). Tie-breaker is F1.
 
 Notes and defaults:
 
 - If `SPY_MIN_CONF` is not set and `select_best_threshold` cannot determine a threshold (no labels
-  or runs available), the autopilot will fall back to a conservative default of `0.25`.
+or runs available), the autopilot will fall back to a conservative default of `0.25`.
 - The SPY extractor computes a per-token confidence as `delta / max_delta` where `delta` is the run-
-  specific match delta and `max_delta` is the maximum delta observed in that run's scan. The `--min-
-  conf` threshold is applied to that normalized confidence to decide which tokens to emit.
+specific match delta and `max_delta` is the maximum delta observed in that run's scan. The `--min-
+conf` threshold is applied to that normalized confidence to decide which tokens to emit.
 
 Example: evaluating thresholds
 
@@ -61,15 +61,15 @@ print('Best threshold:', best)
 ## Artifacts
 
 - Tuning runs: `artifacts/tuning_runs/run_<timestamp>/` containing `crib_weight_sweep.csv` and
-  `weight_*_details.csv`.
+`weight_*_details.csv`.
 - Demo runs: `artifacts/demo/run_<timestamp>/` produced by `scripts/demo/run_k4_demo.py`.
 
 ## CI
 
 - Fast CI (`.github/workflows/ci-fast.yml`) runs tests quickly and installs the package in editable
-  mode.
+mode.
 - Slow CI (`.github/workflows/ci-slow.yml`) runs the K4 demo smoke test and uploads artifacts for
-  debugging; it runs on pushes to `main` and manual dispatch.
+debugging; it runs on pushes to `main` and manual dispatch.
 
 ## How to run locally
 

--- a/docs/K4_STRATEGY.md
+++ b/docs/K4_STRATEGY.md
@@ -14,21 +14,21 @@ Related documents / breadcrumbs:
 ## Current Progress (K4-specific)
 
 - Implemented pipeline scaffolding for multi-stage hypotheses (hill, transposition, masking, berlin-
-  clock).
+clock).
 - Integrated attempt logging, scoring heuristics (n-grams, crib bonuses, positional bonuses), and
-  CSV/JSON artifact writers.
+CSV/JSON artifact writers.
 - Added adaptive gating heuristics, parallel hill-variant scaffolding, and a tuning harness
-  scaffold.
+scaffold.
 
 ## K4 Features (detailed)
 
 - Hill cipher solving (2x2 & partial 3x3 exploration) with crib-anchored pruning and assembly
-  variants.
+variants.
 - Columnar and route transposition search, including multi-crib positional anchoring and adaptive
-  sampling.
+sampling.
 - Masking / null-removal heuristics to explore structural padding variants.
 - Berlin Clock enumeration and a small validator to score ordering/occurrence of `BERLIN`/`CLOCK` in
-  plaintexts.
+plaintexts.
 - Composite orchestration, weighted fusion of stage outputs, and per-run diagnostics.
 
 ## Key modules (under `src/k4/`)
@@ -42,15 +42,15 @@ Related documents / breadcrumbs:
 ## Tuning & Daemon Notes
 
 - `scripts/tuning/tune_pipeline.py` contains a minimal sweep harness intended for quick parameter
-  experimentation (use small budgets for local runs).
+experimentation (use small budgets for local runs).
 - `scripts/daemon_runner.py` is a conservative long-loop runner that can execute the tuning harness,
-  apply simple filtering (top-N), and rotate/retain artifacts. It includes a dry-run mode for safe
-  testing.
+apply simple filtering (top-N), and rotate/retain artifacts. It includes a dry-run mode for safe
+testing.
 
 ## Artifacts and format
 
 - Per-run artifacts are written to `artifacts/run_<timestamp>/` or
-  `artifacts/tuning_runs/run_<timestamp>/`.
+`artifacts/tuning_runs/run_<timestamp>/`.
 - Each run contains `summary.csv` and a `*_top.csv` filtered view for quick review.
 
 ## Next K4 priorities (short)
@@ -70,9 +70,9 @@ K4 remains unsolved publicly. Our goal:
 
 - Reconstruct high-confidence ciphertext normalization.
 - Implement systematic candidate generation pipelines (cipher families consistent with design
-  ethos).
+ethos).
 - Integrate objective scoring (language fitness, crib placement, clue satisfaction, linguistic
-  metrics).
+metrics).
 - Maintain reproducibility (config-driven, test harness & artifact lineage + attempt logs).
 
 ### 2. Canonical Data
@@ -103,10 +103,10 @@ positional scoring. See validation in [`tests/test_k4_cribs.py`](../tests/test_k
 
 - K1–K3 show deliberate anomalies → tolerate misspellings/nulls.
 - Clues suggest possible method shift (like K3 shift to pure transposition) → evaluate hybrid
-  approaches (matrix + transposition + key-stream).
+approaches (matrix + transposition + key-stream).
 - CLOCK self-map letter indicates potential polyalphabetic coincidence or matrix edge alignment.
 - Spatial/temporal clues (EAST/NORTHEAST/BERLIN CLOCK) reinforce directional/time-based key schedule
-  hypothesis (Berlin Clock encoding route).
+hypothesis (Berlin Clock encoding route).
 
 ### 4. Candidate Cipher Families (Tracked)
 

--- a/docs/K4_STRATEGY.md
+++ b/docs/K4_STRATEGY.md
@@ -1,19 +1,34 @@
 # K4 Strategy & Technical Notes
 
-This document collects K4-specific strategy, modules, and operational notes used by the analysis pipeline. It's intentionally focused on the unsolved K4 piece and the specialized tooling in `src/k4/`.
+This document collects K4-specific strategy, modules, and operational notes used by the analysis
+pipeline. It's intentionally focused on the unsolved K4 piece and the specialized tooling in
+`src/k4/`.
+
+Related documents / breadcrumbs:
+
+- Project core: `README_CORE.md`
+- Autopilot: `AUTOPILOT.md`
+- Plan: `PLAN.md`
+- Roadmap: `../ROADMAP.md`
 
 ## Current Progress (K4-specific)
 
-- Implemented pipeline scaffolding for multi-stage hypotheses (hill, transposition, masking, berlin-clock).
-- Integrated attempt logging, scoring heuristics (n-grams, crib bonuses, positional bonuses), and CSV/JSON artifact writers.
-- Added adaptive gating heuristics, parallel hill-variant scaffolding, and a tuning harness scaffold.
+- Implemented pipeline scaffolding for multi-stage hypotheses (hill, transposition, masking, berlin-
+  clock).
+- Integrated attempt logging, scoring heuristics (n-grams, crib bonuses, positional bonuses), and
+  CSV/JSON artifact writers.
+- Added adaptive gating heuristics, parallel hill-variant scaffolding, and a tuning harness
+  scaffold.
 
 ## K4 Features (detailed)
 
-- Hill cipher solving (2x2 & partial 3x3 exploration) with crib-anchored pruning and assembly variants.
-- Columnar and route transposition search, including multi-crib positional anchoring and adaptive sampling.
+- Hill cipher solving (2x2 & partial 3x3 exploration) with crib-anchored pruning and assembly
+  variants.
+- Columnar and route transposition search, including multi-crib positional anchoring and adaptive
+  sampling.
 - Masking / null-removal heuristics to explore structural padding variants.
-- Berlin Clock enumeration and a small validator to score ordering/occurrence of `BERLIN`/`CLOCK` in plaintexts.
+- Berlin Clock enumeration and a small validator to score ordering/occurrence of `BERLIN`/`CLOCK` in
+  plaintexts.
 - Composite orchestration, weighted fusion of stage outputs, and per-run diagnostics.
 
 ## Key modules (under `src/k4/`)
@@ -26,21 +41,26 @@ This document collects K4-specific strategy, modules, and operational notes used
 
 ## Tuning & Daemon Notes
 
-- `scripts/tuning/tune_pipeline.py` contains a minimal sweep harness intended for quick parameter experimentation (use small budgets for local runs).
-- `scripts/daemon_runner.py` is a conservative long-loop runner that can execute the tuning harness, apply simple filtering (top-N), and rotate/retain artifacts. It includes a dry-run mode for safe testing.
+- `scripts/tuning/tune_pipeline.py` contains a minimal sweep harness intended for quick parameter
+  experimentation (use small budgets for local runs).
+- `scripts/daemon_runner.py` is a conservative long-loop runner that can execute the tuning harness,
+  apply simple filtering (top-N), and rotate/retain artifacts. It includes a dry-run mode for safe
+  testing.
 
 ## Artifacts and format
 
-- Per-run artifacts are written to `artifacts/run_<timestamp>/` or `artifacts/tuning_runs/run_<timestamp>/`.
+- Per-run artifacts are written to `artifacts/run_<timestamp>/` or
+  `artifacts/tuning_runs/run_<timestamp>/`.
 - Each run contains `summary.csv` and a `*_top.csv` filtered view for quick review.
 
 ## Next K4 priorities (short)
 
-1. Close remaining scoring coverage gaps and add transposition edge-case tests.
-2. Implement deterministic small sweeps and iterate weighting heuristics.
-3. Deploy the daemon runner and collect longer campaigns for candidate analysis.
+1. Close remaining scoring coverage gaps and add transposition edge-case tests. 2. Implement
+deterministic small sweeps and iterate weighting heuristics. 3. Deploy the daemon runner and collect
+longer campaigns for candidate analysis.
 
-For operational details and code-level examples, refer to the module docstrings in `src/k4/` and the quick examples in `docs/README_CORE.md`.
+For operational details and code-level examples, refer to the module docstrings in `src/k4/` and the
+quick examples in `docs/README_CORE.md`.
 
 ## Kryptos K4 Research & Strategy
 
@@ -49,8 +69,10 @@ For operational details and code-level examples, refer to the module docstrings 
 K4 remains unsolved publicly. Our goal:
 
 - Reconstruct high-confidence ciphertext normalization.
-- Implement systematic candidate generation pipelines (cipher families consistent with design ethos).
-- Integrate objective scoring (language fitness, crib placement, clue satisfaction, linguistic metrics).
+- Implement systematic candidate generation pipelines (cipher families consistent with design
+  ethos).
+- Integrate objective scoring (language fitness, crib placement, clue satisfaction, linguistic
+  metrics).
 - Maintain reproducibility (config-driven, test harness & artifact lineage + attempt logs).
 
 ### 2. Canonical Data
@@ -61,7 +83,8 @@ Ciphertext (per sculpture transcription; spaces inserted for readability):
 OBKR UOXOGHULBSOLIFBBWFLRVQQPRNGKSSO TWTQSJQSSEKZZWATJKLUDIAWINFBNYPVTT MZFPKWGDKZXTJCDIGKUHUAUEKCAR
 ```
 
-Known plaintext cribs (confirmed by Sanborn) with expected start indices (0-based for analysis convenience):
+Known plaintext cribs (confirmed by Sanborn) with expected start indices (0-based for analysis
+convenience):
 
 | Plain | Expected Index | Cipher Segment |
 |-------|----------------|----------------|
@@ -72,23 +95,25 @@ Known plaintext cribs (confirmed by Sanborn) with expected start indices (0-base
 
 #### Index Corrections
 
-Indices have been validated; the table above shows the corrected values (NORTHEAST=25, CLOCK=69). Prior values (NORTHEAST=26 and CLOCK=70) were off-by-one errors. These have been harmonized for positional scoring. See validation in [`tests/test_k4_cribs.py`](../tests/test_k4_cribs.py).
+Indices have been validated; the table above shows the corrected values (NORTHEAST=25, CLOCK=69).
+Prior values (NORTHEAST=26 and CLOCK=70) were off-by-one errors. These have been harmonized for
+positional scoring. See validation in [`tests/test_k4_cribs.py`](../tests/test_k4_cribs.py).
 
 ### 3. Constraints & Observations
 
 - K1–K3 show deliberate anomalies → tolerate misspellings/nulls.
-- Clues suggest possible method shift (like K3 shift to pure transposition) → evaluate hybrid approaches (matrix + transposition + key-stream).
+- Clues suggest possible method shift (like K3 shift to pure transposition) → evaluate hybrid
+  approaches (matrix + transposition + key-stream).
 - CLOCK self-map letter indicates potential polyalphabetic coincidence or matrix edge alignment.
-- Spatial/temporal clues (EAST/NORTHEAST/BERLIN CLOCK) reinforce directional/time-based key schedule hypothesis (Berlin Clock encoding route).
+- Spatial/temporal clues (EAST/NORTHEAST/BERLIN CLOCK) reinforce directional/time-based key schedule
+  hypothesis (Berlin Clock encoding route).
 
 ### 4. Candidate Cipher Families (Tracked)
 
-1. Polyalphabetic / key-stream (Berlin Clock derived shifts). [IN PROGRESS]
-2. Columnar / double transposition with anchored cribs. [IN PROGRESS]
-3. Hill cipher (2x2, 3x3 constrained by cribs). [IN PROGRESS]
-4. Masking / null removal to expose latent structure. [COMPLETED (stage)]
-5. Hybrid matrix + transposition chain. [PLANNED]
-6. Progressive key (autokey/Berlin-lamp injection). [PLANNED]
+1. Polyalphabetic / key-stream (Berlin Clock derived shifts). [IN PROGRESS] 2. Columnar / double
+transposition with anchored cribs. [IN PROGRESS] 3. Hill cipher (2x2, 3x3 constrained by cribs). [IN
+PROGRESS] 4. Masking / null removal to expose latent structure. [COMPLETED (stage)] 5. Hybrid matrix
++ transposition chain. [PLANNED] 6. Progressive key (autokey/Berlin-lamp injection). [PLANNED]
 
 ### 5. Prioritization Status
 
@@ -103,7 +128,8 @@ Indices have been validated; the table above shows the corrected values (NORTHEA
 
 ### 6. Data Normalization Tasks
 
-DONE: normalization utilities; still ensure consistent indexing for positional scoring (verify EAST/NORTHEAST alignment). Pending: automatic index validation test.
+DONE: normalization utilities; still ensure consistent indexing for positional scoring (verify
+EAST/NORTHEAST alignment). Pending: automatic index validation test.
 
 ### 7. Scoring Components (Implemented)
 
@@ -123,7 +149,8 @@ DONE: normalization utilities; still ensure consistent indexing for positional s
 - Partial score pruning for 3x3 candidates (reduce evaluation expense).
 - Attempt logging for each key attempt (pruned & successful) → persisted via composite run.
 
-Next: Evaluate additional assembly heuristics (spiral, snake) and consider plaintext/cipher swapped orientation tests (P = K*C vs C = K*P) with small sample.
+Next: Evaluate additional assembly heuristics (spiral, snake) and consider plaintext/cipher swapped
+orientation tests (P = K*C vs C = K*P) with small sample.
 
 ### 9. Transposition Constraint Solver (Current State)
 
@@ -131,7 +158,8 @@ Next: Evaluate additional assembly heuristics (spiral, snake) and consider plain
 - Multi-crib positional stage enumerating permutations satisfying window constraints.
 - Attempt logging at permutation level (search & adaptive).
 
-Next: Integrate simultaneous alignment scoring (weighted by rarity of alignment probability) and add route-transposition patterns.
+Next: Integrate simultaneous alignment scoring (weighted by rarity of alignment probability) and add
+route-transposition patterns.
 
 ### 10. Berlin Clock Key Stream (Current State)
 
@@ -139,12 +167,14 @@ Next: Integrate simultaneous alignment scoring (weighted by rarity of alignment 
 - Dual-direction shift application (forward/backward) enumerated across time range.
 - Attempt logging per time-mode combination.
 
-Next: Derive candidate reference times (historical events) and cluster high scoring intervals; refine by dynamic step reduction near promising hours.
+Next: Derive candidate reference times (historical events) and cluster high scoring intervals;
+refine by dynamic step reduction near promising hours.
 
 ### 11. Testing Infrastructure
 
-Completed: Unit tests for scoring, Hill, transposition, Berlin Clock, masking, fusion, entropy metrics, positional constraints.
-Pending: Tests for attempt log persistence artifact and multi-crib stage correctness (positions captured). Add failure mode tests (pruned keys/perms recorded).
+Completed: Unit tests for scoring, Hill, transposition, Berlin Clock, masking, fusion, entropy
+metrics, positional constraints. Pending: Tests for attempt log persistence artifact and multi-crib
+stage correctness (positions captured). Add failure mode tests (pruned keys/perms recorded).
 
 ### 12. Workflow Log (Recent Updates)
 
@@ -160,27 +190,27 @@ Pending: Tests for attempt log persistence artifact and multi-crib stage correct
 
 ### 13. Performance & Optimization
 
-Implemented: LRU caching, partial score pruning, prefix caching.
-Next: Profile hotspots for 3x3 key generation & multi-crib permutation enumeration; implement parallelization option (multiprocessing) for heavy search stages.
+Implemented: LRU caching, partial score pruning, prefix caching. Next: Profile hotspots for 3x3 key
+generation & multi-crib permutation enumeration; implement parallelization option (multiprocessing)
+for heavy search stages.
 
 ### 14. Artifact & Reproducibility
 
-Implemented: Candidate JSON/CSV with metrics + transformation trace + lineage; attempt logs persisted in timestamped JSON.
-Next: Add compression option & integrate provenance hash of ciphertext + parameters.
+Implemented: Candidate JSON/CSV with metrics + transformation trace + lineage; attempt logs
+persisted in timestamped JSON. Next: Add compression option & integrate provenance hash of
+ciphertext + parameters.
 
 ### 15. Updated Next Actions
 
-1. Refine route transposition scoring (add positional crib bonus integration).
-2. Expand 3x3 Hill assemblies (spiral, column zigzag) + orientation flip tests.
-3. Probability-weighted multi-crib scoring (rarity weighting vs simple bonus).
-4. Multiprocessing / parallel stage execution benchmarking.
-5. Failure mode tests for pruning (assert pruned recorded correctly).
-6. Refine adaptive fusion weighting thresholds (entropy band & bonuses).
-7. Add diagonal-start variants (anti-diagonal snake) & perimeter-in/out variants.
+1. Refine route transposition scoring (add positional crib bonus integration). 2. Expand 3x3 Hill
+assemblies (spiral, column zigzag) + orientation flip tests. 3. Probability-weighted multi-crib
+scoring (rarity weighting vs simple bonus). 4. Multiprocessing / parallel stage execution
+benchmarking. 5. Failure mode tests for pruning (assert pruned recorded correctly). 6. Refine
+adaptive fusion weighting thresholds (entropy band & bonuses). 7. Add diagonal-start variants (anti-
+diagonal snake) & perimeter-in/out variants.
 
 ### 16. References
 
 (See README for links; add matrix conjecture, entropy references.)
 
----
-Updated: 2025-10-21
+--- Updated: 2025-10-21

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -11,74 +11,74 @@ Related documents / breadcrumbs:
 - Autopilot details: `AUTOPILOT.md`
 - Roadmap: `../ROADMAP.md`
 
-Top priorities (next iteration):
+- Top priorities (next iteration):
 
 - [ ] 1) Finish focused unit tests for `src/k4/scoring.py` to cover edge branches and rare code
-  paths. Acceptance: scoring tests green and file coverage >= 95%.
+paths. Acceptance: scoring tests green and file coverage >= 95%.
 - [ ] 2) Add unit tests for `src/k4/transposition.py` covering early-exit/route edge cases.
-  Acceptance: transposition tests green and file coverage >= 90%.
-- [ ] 3) Wire and validate a deterministic tiny tuning sweep (`scripts/tuning/crib_weight_sweep.py`
-  is the canonical harness) with small budgets. Acceptance: artifacts written to
-  `artifacts/tuning_runs/run_<ts>/` containing `crib_weight_sweep.csv` and per-weight detail files.
-- [ ] 4) Integrate SPY threshold selection into the autopilot runner so `ask_triumverate.py` will
-  compute a conservative `SPY_MIN_CONF` from labeled runs if not set. Acceptance: autopilot dry-run
-  invokes SPY with computed threshold and `agents/LEARNED.md` updated in full-run mode.
+Acceptance: transposition tests green and file coverage >= 90%.
+- [ ] 3) Wire and validate a deterministic tiny tuning sweep (canonical:
+`scripts/tuning/crib_weight_sweep.py`) with small budgets. Acceptance: artifacts written to
+`artifacts/tuning_runs/run_<ts>/` containing `crib_weight_sweep.csv` and per-weight detail files.
+- [ ] 4) Integrate SPY threshold selection into the autopilot runner so `ask_triumverate.py`
+computes a conservative `SPY_MIN_CONF` when unset. Acceptance: autopilot dry-run invokes SPY with
+computed threshold and `agents/LEARNED.md` updated in full-run mode.
 - [ ] 5) Run full test suite and confirm overall coverage remains high (target >= 92%).
 
 Progress note:
 
 - We made more progress than expected today — core pipeline, scoring extensions, CSV artifacts,
-  adaptive gating, and multiple unit tests are already in place and the full test suite runs quickly
-  (~3s locally) with total coverage >92%.
+adaptive gating, and multiple unit tests are already in place and the full test suite runs quickly
+(~3s locally) with total coverage >92%.
 - Given that momentum, the remaining items are focused and should be achievable on the timetable
-  below.
+below.
 
 Timetable (practical schedule)
 
 - Day 0 (now, 0–4 hours): finish scoring tests (in-progress). Acceptance: `src/k4/scoring.py` >95%
-  coverage; tests green locally.
+coverage; tests green locally.
 - Day 0 (next 2–4 hours): add transposition tests. Acceptance: `src/k4/transposition.py` >90%
-  coverage; tests green.
+coverage; tests green.
 - Day 0–1 (3–6 hours): wire tiny deterministic tuning sweep (4 combos) in
-  `scripts/tune_pipeline.py`. Acceptance: `artifacts/tuning_runs/*.csv` with 4 rows and headers.
+`scripts/tune_pipeline.py`. Acceptance: `artifacts/tuning_runs/*.csv` with 4 rows and headers.
 - Day 0–1 (3–6 hours): validate the deterministic tuning sweep
-  (`scripts/tuning/crib_weight_sweep.py`) with a small grid and verify CSV artifacts are produced.
-  Acceptance: artifacts exist and per-weight detail files present.
+(`scripts/tuning/crib_weight_sweep.py`) with a small grid and verify CSV artifacts are produced.
+Acceptance: artifacts exist and per-weight detail files present.
 - Day 1 (0.5–1 hour): run full suite + coverage, produce summary, archive today's close-up to
-  `PLAN_ARCHIVE/2025-10-22.md`.
+`PLAN_ARCHIVE/2025-10-22.md`.
 - Day 1–3 (1–3 days): iterative tuning and short search loops to refine scoring weights and gating
-  heuristics until candidate quality stabilizes. Expect manual review of top candidates after each
-  run.
+heuristics until candidate quality stabilizes. Expect manual review of top candidates after each
+run.
 - Day 3–5 (1 day to set up, then continuous): implement long-loop runner/daemon to run sweeps
-  automatically and rotate parameter sets; then monitor artifacts and alerts.
+automatically and rotate parameter sets; then monitor artifacts and alerts.
 
 Quick success checkpoints
 
 - Short-term: tests green, scoring & transposition files >90–95% coverage, tuning harness writes
-  CSVs.
+CSVs.
 - Mid-term: several short sweeps produce repeatable top candidates that pass manual inspection
-  checks (crib hits, wordlist hit-rate).
+checks (crib hits, wordlist hit-rate).
 - Long-term: continuous runner produces stable daily artifacts and a manageable queue of leads for
-  manual analysis.
+manual analysis.
 
 Stretch tasks (if time permits):
 
 - [ ] 5) Add one integration smoke test that executes the pipeline on a short ciphertext and asserts
-  artifact files exist and contain expected headers/keys.
+artifact files exist and contain expected headers/keys.
 - [ ] 6) Remove deprecated autofix stubs after a quick code review (or move them to
-  `tools/deprecated/`).
+`tools/deprecated/`).
 
 Execution plan and acceptance criteria:
 
 - For scoring tests: aim to add small isolated inputs that trigger chi-square early returns,
-  quadgram fallbacks, baseline_stats branches, and letter_entropy edge cases.
+quadgram fallbacks, baseline_stats branches, and letter_entropy edge cases.
 - For transposition: create compact fixtures with constrained column ranges and cribs to force the
-  transposition code into the missing branches.
+transposition code into the missing branches.
 - For tuning sweep: run 4 quick parameter combinations and assert CSV produced with 4 rows; sweep
-  must complete in < 30s locally.
+must complete in < 30s locally.
 
 Notes:
 
 - I'll update the todo list and start with the scoring tests. I expect to complete priorities 1–3
-  within today's session.
+within today's session.
 - After finishing, I'll write a short summary and update `PLAN_ARCHIVE` with the day's close-up.

--- a/docs/PLAN_ARCHIVE/2025-10-21.md
+++ b/docs/PLAN_ARCHIVE/2025-10-21.md
@@ -7,21 +7,24 @@ Done:
 - Stage interface spec and placeholder types implemented.
 - Unit tests for stage interface and negative pruning behavior added.
 - Extended scoring with crib bonuses and Berlin clock validator; added cached combined scoring.
-- Pipeline executor implemented with pruning, CSV artifact export, dynamic gating heuristics, and performance counters.
+- Pipeline executor implemented with pruning, CSV artifact export, dynamic gating heuristics, and
+  performance counters.
 - Parallel hill-variant scaffolding added.
 - Tuning harness scaffold (`scripts/tune_pipeline.py`) created.
 - Multiple unit tests added; coverage raised above 92% (total ~92.8%).
 
 Pending (short list):
 
-- Close remaining coverage gaps in `src/k4/scoring.py` (target branches ~135-157 and related edge cases).
+- Close remaining coverage gaps in `src/k4/scoring.py` (target branches ~135-157 and related edge
+  cases).
 - Add transposition edge-case tests to bring `src/k4/transposition.py` above 90%.
 - Finalize tuning script and run initial parameter sweeps.
 - Optionally remove deprecated autofix stubs after review.
 
 Notes:
 
-- Tests are fast; full suite runs in ~3s locally and produces artifacts in `artifacts/run_<timestamp>/` on sample runs.
+- Tests are fast; full suite runs in ~3s locally and produces artifacts in
+  `artifacts/run_<timestamp>/` on sample runs.
 - `tests/conftest.py` centralizes path setup for reliable test imports.
 
 — end of day

--- a/docs/PLAN_ARCHIVE/2025-10-21.md
+++ b/docs/PLAN_ARCHIVE/2025-10-21.md
@@ -8,7 +8,7 @@ Done:
 - Unit tests for stage interface and negative pruning behavior added.
 - Extended scoring with crib bonuses and Berlin clock validator; added cached combined scoring.
 - Pipeline executor implemented with pruning, CSV artifact export, dynamic gating heuristics, and
-  performance counters.
+performance counters.
 - Parallel hill-variant scaffolding added.
 - Tuning harness scaffold (`scripts/tune_pipeline.py`) created.
 - Multiple unit tests added; coverage raised above 92% (total ~92.8%).
@@ -16,7 +16,7 @@ Done:
 Pending (short list):
 
 - Close remaining coverage gaps in `src/k4/scoring.py` (target branches ~135-157 and related edge
-  cases).
+cases).
 - Add transposition edge-case tests to bring `src/k4/transposition.py` above 90%.
 - Finalize tuning script and run initial parameter sweeps.
 - Optionally remove deprecated autofix stubs after review.
@@ -24,7 +24,7 @@ Pending (short list):
 Notes:
 
 - Tests are fast; full suite runs in ~3s locally and produces artifacts in
-  `artifacts/run_<timestamp>/` on sample runs.
+`artifacts/run_<timestamp>/` on sample runs.
 - `tests/conftest.py` centralizes path setup for reliable test imports.
 
 — end of day

--- a/docs/PLAN_ARCHIVE/2025-10-22.md
+++ b/docs/PLAN_ARCHIVE/2025-10-22.md
@@ -1,3 +1,11 @@
+# Plan snapshot — 2025-10-22
+
+This archive contains the plan file as of 2025-10-22 for traceability.
+
+---
+
+```markdown
+
 # Plan for 2025-10-22
 
 Short goal: Align development activities towards reproducible candidate discovery for K4 by
@@ -13,17 +21,28 @@ Related documents / breadcrumbs:
 
 Top priorities (next iteration):
 
-- [ ] 1) Finish focused unit tests for `src/k4/scoring.py` to cover edge branches and rare code
+ - [ ] 1) Finish focused unit tests for `src/k4/scoring.py` to cover edge branches and rare code
   paths. Acceptance: scoring tests green and file coverage >= 95%.
-- [ ] 2) Add unit tests for `src/k4/transposition.py` covering early-exit/route edge cases.
+ - [ ] 2) Add unit tests for `src/k4/transposition.py` covering early-exit/route edge cases.
   Acceptance: transposition tests green and file coverage >= 90%.
-- [ ] 3) Wire and validate a deterministic tiny tuning sweep (`scripts/tuning/crib_weight_sweep.py`
+ - [ ] 3) Wire and validate a deterministic tiny tuning sweep (`scripts/tuning/crib_weight_sweep.py`
   is the canonical harness) with small budgets. Acceptance: artifacts written to
   `artifacts/tuning_runs/run_<ts>/` containing `crib_weight_sweep.csv` and per-weight detail files.
-- [ ] 4) Integrate SPY threshold selection into the autopilot runner so `ask_triumverate.py` will
+ - [ ] 4) Integrate SPY threshold selection into the autopilot runner so `ask_triumverate.py` will
   compute a conservative `SPY_MIN_CONF` from labeled runs if not set. Acceptance: autopilot dry-run
   invokes SPY with computed threshold and `agents/LEARNED.md` updated in full-run mode.
-- [ ] 5) Run full test suite and confirm overall coverage remains high (target >= 92%).
+ - [ ] 5) Run full test suite and confirm overall coverage remains high (target >= 92%).
+ - [ ] 1) Finish focused unit tests for `src/k4/scoring.py` to cover edge branches and rare code
+   paths. Acceptance: scoring tests green and file coverage >= 95%.
+ - [ ] 2) Add unit tests for `src/k4/transposition.py` covering early-exit/route edge cases.
+   Acceptance: transposition tests green and file coverage >= 90%.
+ - [ ] 3) Wire and validate a deterministic tiny tuning sweep (`scripts/tuning/crib_weight_sweep.py`
+   is the canonical harness) with small budgets. Acceptance: artifacts written to
+   `artifacts/tuning_runs/run_<ts>/` containing `crib_weight_sweep.csv` and per-weight detail files.
+ - [ ] 4) Integrate SPY threshold selection into the autopilot runner so `ask_triumverate.py` will
+   compute a conservative `SPY_MIN_CONF` from labeled runs if not set. Acceptance: autopilot dry-run
+   invokes SPY with computed threshold and `agents/LEARNED.md` updated in full-run mode.
+ - [ ] 5) Run full test suite and confirm overall coverage remains high (target >= 92%).
 
 Progress note:
 
@@ -81,4 +100,5 @@ Notes:
 
 - I'll update the todo list and start with the scoring tests. I expect to complete priorities 1–3
   within today's session.
-- After finishing, I'll write a short summary and update `PLAN_ARCHIVE` with the day's close-up.
+After finishing, I'll write a short summary and update `PLAN_ARCHIVE` with the day's close-up.
+```

--- a/docs/README_CORE.md
+++ b/docs/README_CORE.md
@@ -1,12 +1,17 @@
 # KRYPTOS — Core Documentation
 
-This file contains the detailed project overview, features, modules, and quick-start examples for the KRYPTOS project. The top-level `README.md` is intentionally concise — use this document for in-depth reference.
+This file contains the detailed project overview, features, modules, and quick-start examples for
+the KRYPTOS project. The top-level `README.md` is intentionally concise — use this document for in-
+depth reference.
 
 ## TL;DR
 
-K4 is the unsolved section of the Kryptos sculpture. This repository contains a toolkit to explore layered cipher hypotheses (Hill, transposition, masking, Berlin Clock shift hypotheses) and a configurable pipeline to score and rank candidate plaintexts.
+K4 is the unsolved section of the Kryptos sculpture. This repository contains a toolkit to explore
+layered cipher hypotheses (Hill, transposition, masking, Berlin Clock shift hypotheses) and a
+configurable pipeline to score and rank candidate plaintexts.
 
-This repository contains code, tests, data, and documentation to run and extend experiments. K4-specific strategy and deep technical notes live under `docs/K4_STRATEGY.md`.
+This repository contains code, tests, data, and documentation to run and extend experiments.
+K4-specific strategy and deep technical notes live under `docs/K4_STRATEGY.md`.
 
 ### Quick links
 
@@ -16,6 +21,13 @@ This repository contains code, tests, data, and documentation to run and extend 
 - Daily plan: `PLAN.md`
 - Tuning/daemon runner: `scripts/tune_pipeline.py`, `scripts/daemon_runner.py`
 - Tests: `tests/` (run with `python -m unittest discover -s tests`)
+
+Related documents / breadcrumbs:
+
+- Autopilot & SPY: `AUTOPILOT.md`
+- Plan: `PLAN.md`
+- Roadmap: `../ROADMAP.md`
+- Top-level README: `../README.md`
 
 ### Highlights
 
@@ -27,7 +39,8 @@ This repository contains code, tests, data, and documentation to run and extend 
 ## Current Progress
 
 - Implemented K1–K3 verified tooling and tests.
-- K4: implemented multi-stage pipeline scaffolding, scoring utilities, attempt logging, and adaptive gating.
+- K4: implemented multi-stage pipeline scaffolding, scoring utilities, attempt logging, and adaptive
+  gating.
 - Added unit tests and a tuning harness scaffold; artifacts written to `artifacts/` during runs.
 
 ## Features (summary)
@@ -61,16 +74,20 @@ pip install -r requirements.txt
 python -m unittest discover -s tests
 ```
 
-1. Run a tiny pipeline sample (see `scripts/tools/run_pipeline_sample.py` for an example of how to call the pipeline programmatically).
+1. Run a tiny pipeline sample (see `scripts/tools/run_pipeline_sample.py` for an example of how to
+call the pipeline programmatically).
 
 ## How to Use the Tuning Harness
 
-- `scripts/tuning/tune_pipeline.py` contains a small sweep harness. For safe local experiments, use the dry-run mode or set small candidate budgets.
-- The daemon runner `scripts/daemon_runner.py` provides a minimal long-loop runner that writes CSV artifacts to `artifacts/tuning_runs/` and retains the last 20 runs.
+- `scripts/tuning/tune_pipeline.py` contains a small sweep harness. For safe local experiments, use
+  the dry-run mode or set small candidate budgets.
+- The daemon runner `scripts/daemon_runner.py` provides a minimal long-loop runner that writes CSV
+  artifacts to `artifacts/tuning_runs/` and retains the last 20 runs.
 
 ## Artifacts
 
-- Attempt logs and run summaries are placed under `artifacts/run_<timestamp>/` or `artifacts/tuning_runs/run_<timestamp>/` when using the tuning harness or daemon.
+- Attempt logs and run summaries are placed under `artifacts/run_<timestamp>/` or
+  `artifacts/tuning_runs/run_<timestamp>/` when using the tuning harness or daemon.
 
 ## Roadmap & Contributing
 
@@ -79,9 +96,11 @@ python -m unittest discover -s tests
 
 ## Data Sources
 
-- N-gram and frequency data live in `data/` as TSVs; the code falls back to reasonable defaults when files are missing.
+- N-gram and frequency data live in `data/` as TSVs; the code falls back to reasonable defaults when
+  files are missing.
 
 ## License & References
 
 - See `LICENSE` for licensing.
-- References and further reading are in the original README and in-line documentation within `docs/`.
+- References and further reading are in the original README and in-line documentation within
+  `docs/`.

--- a/docs/README_CORE.md
+++ b/docs/README_CORE.md
@@ -40,7 +40,7 @@ Related documents / breadcrumbs:
 
 - Implemented K1–K3 verified tooling and tests.
 - K4: implemented multi-stage pipeline scaffolding, scoring utilities, attempt logging, and adaptive
-  gating.
+gating.
 - Added unit tests and a tuning harness scaffold; artifacts written to `artifacts/` during runs.
 
 ## Features (summary)
@@ -80,14 +80,14 @@ call the pipeline programmatically).
 ## How to Use the Tuning Harness
 
 - `scripts/tuning/tune_pipeline.py` contains a small sweep harness. For safe local experiments, use
-  the dry-run mode or set small candidate budgets.
+the dry-run mode or set small candidate budgets.
 - The daemon runner `scripts/daemon_runner.py` provides a minimal long-loop runner that writes CSV
-  artifacts to `artifacts/tuning_runs/` and retains the last 20 runs.
+artifacts to `artifacts/tuning_runs/` and retains the last 20 runs.
 
 ## Artifacts
 
 - Attempt logs and run summaries are placed under `artifacts/run_<timestamp>/` or
-  `artifacts/tuning_runs/run_<timestamp>/` when using the tuning harness or daemon.
+`artifacts/tuning_runs/run_<timestamp>/` when using the tuning harness or daemon.
 
 ## Roadmap & Contributing
 
@@ -97,10 +97,10 @@ call the pipeline programmatically).
 ## Data Sources
 
 - N-gram and frequency data live in `data/` as TSVs; the code falls back to reasonable defaults when
-  files are missing.
+files are missing.
 
 ## License & References
 
 - See `LICENSE` for licensing.
 - References and further reading are in the original README and in-line documentation within
-  `docs/`.
+`docs/`.

--- a/docs/SANBORN.md
+++ b/docs/SANBORN.md
@@ -1,52 +1,89 @@
 # Jim Sanborn — notes and research pointers
 
-This note collects what is publicly known or widely reported about Jim Sanborn (the sculptor who created the Kryptos piece), the kinds of clues he has given publicly, and pragmatic next steps for researching artist-level hints that might inform K4 hypotheses.
+This note collects what is publicly known or widely reported about Jim Sanborn (the sculptor who
+created the Kryptos piece), the kinds of clues he has given publicly, and pragmatic next steps for
+researching artist-level hints that might inform K4 hypotheses.
 
-Use this as an operational checklist rather than an authoritative biography. Always verify anything you plan to treat as a crib or hard constraint against a primary source (interview transcript, museum statement, archived press release, or Sanborn's own website).
+Use this as an operational checklist rather than an authoritative biography. Always verify anything
+you plan to treat as a crib or hard constraint against a primary source (interview transcript,
+museum statement, archived press release, or Sanborn's own website).
 
 ## High-level, well-established facts
 
-- Jim Sanborn is the artist who created the Kryptos sculpture. The sculpture is installed at the CIA headquarters grounds in Langley, Virginia.
-- Kryptos is an art piece that intentionally incorporates encrypted text and layered puzzles. Several sections (commonly labelled K1–K3) have been solved publicly; one section (K4) remains widely reported as unsolved.
-- Over the years Sanborn has answered questions and given limited clues or clarifications in public interviews, artist statements, and correspondence with the community. He has also been careful about what he releases publicly — many clues are partial and intended to nudge rather than hand over the solution.
+- Jim Sanborn is the artist who created the Kryptos sculpture. The sculpture is installed at the CIA
+  headquarters grounds in Langley, Virginia.
+- Kryptos is an art piece that intentionally incorporates encrypted text and layered puzzles.
+  Several sections (commonly labelled K1–K3) have been solved publicly; one section (K4) remains
+  widely reported as unsolved.
+- Over the years Sanborn has answered questions and given limited clues or clarifications in public
+  interviews, artist statements, and correspondence with the community. He has also been careful
+  about what he releases publicly — many clues are partial and intended to nudge rather than hand
+  over the solution.
 
 ## Characteristics of artist-level clues (what to look for)
 
-- The artist often frames context in terms of geography, time, and artifact metaphor: place names, clocks/time references, and directional words appear in the sculpture's plaintext and in reported cribs.
-- Deliberate misspellings and orthographic anomalies appear in solved sections; these are likely part of Sanborn's design language and may repeat as a theme (e.g., nonstandard spellings preserved rather than corrected).
-- Sanborn's public remarks can be terse and poetic; a seemingly throwaway phrase in an interview may be meant as a hint rather than pure commentary.
+- The artist often frames context in terms of geography, time, and artifact metaphor: place names,
+  clocks/time references, and directional words appear in the sculpture's plaintext and in reported
+  cribs.
+- Deliberate misspellings and orthographic anomalies appear in solved sections; these are likely
+  part of Sanborn's design language and may repeat as a theme (e.g., nonstandard spellings preserved
+  rather than corrected).
+- Sanborn's public remarks can be terse and poetic; a seemingly throwaway phrase in an interview may
+  be meant as a hint rather than pure commentary.
 
 ## Research sources to collect (priority order)
 
-1. Sanborn's own website, gallery listings, or artist statements — primary and preferred.
-2. Contemporary press coverage and exhibition notes from the time of installation (press releases, museum/CIA publications).
-3. Transcripts and recordings of interviews with Sanborn where he discusses Kryptos; pay attention to offhand details about sources, inspirations, or words he repeats.
-4. Archive threads and community-sourced timelines (Kryptos Wiki pages, well-documented blog posts). Use these as pointers but verify primary claims before treating them as cribs.
-5. Scholarly or journalistic treatments that analyze the sculpture's iconography and references — these sometimes surface overlooked contextual clues.
+1. Sanborn's own website, gallery listings, or artist statements — primary and preferred. 2.
+Contemporary press coverage and exhibition notes from the time of installation (press releases,
+museum/CIA publications). 3. Transcripts and recordings of interviews with Sanborn where he
+discusses Kryptos; pay attention to offhand details about sources, inspirations, or words he
+repeats. 4. Archive threads and community-sourced timelines (Kryptos Wiki pages, well-documented
+blog posts). Use these as pointers but verify primary claims before treating them as cribs. 5.
+Scholarly or journalistic treatments that analyze the sculpture's iconography and references — these
+sometimes surface overlooked contextual clues.
 
 ## Practical hypotheses to prioritize for K4 (how artist clues map to cipher hypotheses)
 
-- Time-based keying: any mention of clocks, temporal events, or numerically-encoded times suggests testing key-streams derived from clock encodings (e.g., Berlin Clock / Mengenlehreuhr patterns, historical timestamps).
-- Geographic and directional anchors: repeated place names (cities, cardinal directions) suggest positional crib bonuses and multi-crib positional transposition stages — prioritize cribs that align to reported indices.
-- Intentional misspellings: treat misspellings and anomalies as canonical plaintext rather than noise when scoring and when building crib constraints.
-- Artist-supplied words or phrases: when Sanborn mentions words he used in the piece (even in passing), treat those as high-priority cribs but validate their start indices before hard-constraining.
+- Time-based keying: any mention of clocks, temporal events, or numerically-encoded times suggests
+  testing key-streams derived from clock encodings (e.g., Berlin Clock / Mengenlehreuhr patterns,
+  historical timestamps).
+- Geographic and directional anchors: repeated place names (cities, cardinal directions) suggest
+  positional crib bonuses and multi-crib positional transposition stages — prioritize cribs that
+  align to reported indices.
+- Intentional misspellings: treat misspellings and anomalies as canonical plaintext rather than
+  noise when scoring and when building crib constraints.
+- Artist-supplied words or phrases: when Sanborn mentions words he used in the piece (even in
+  passing), treat those as high-priority cribs but validate their start indices before hard-
+  constraining.
 
 ## Suggested next steps (actionable, reproducible)
 
-1. Build a short timeline of Sanborn statements about Kryptos (date, medium, exact quoted text, source URL/archive). Store this as `docs/sources/sanborn_timeline.md` for reproducibility.
-2. Extract candidate one- or two-word cribs that appear in those statements and add them to `config/crubs_candidates.txt` (or equivalent). Treat them as soft cribs first (score boosts), not hard constraints.
-3. Run targeted scoring passes that boost candidates containing those words (positional and non-positional). Compare rank shifts and surface candidates for manual review.
-4. For any mention of dates or times, enumerate small key-stream families derived from time encodings (e.g., 24-hour/12-hour, Berlin-clock lamp patterns) and sweep them with the Berlin-clock stage in a small budget run.
-5. Cross-check artist themes against the sculpture text: if an interview emphasizes a theme (e.g., geography, time, espionage jargon), prioritize scoring features sensitive to those themes (wordlist filters, domain-specific vocabularies).
+1. Build a short timeline of Sanborn statements about Kryptos (date, medium, exact quoted text,
+source URL/archive). Store this as `docs/sources/sanborn_timeline.md` for reproducibility. 2.
+Extract candidate one- or two-word cribs that appear in those statements and add them to
+`config/crubs_candidates.txt` (or equivalent). Treat them as soft cribs first (score boosts), not
+hard constraints. 3. Run targeted scoring passes that boost candidates containing those words
+(positional and non-positional). Compare rank shifts and surface candidates for manual review. 4.
+For any mention of dates or times, enumerate small key-stream families derived from time encodings
+(e.g., 24-hour/12-hour, Berlin-clock lamp patterns) and sweep them with the Berlin-clock stage in a
+small budget run. 5. Cross-check artist themes against the sculpture text: if an interview
+emphasizes a theme (e.g., geography, time, espionage jargon), prioritize scoring features sensitive
+to those themes (wordlist filters, domain-specific vocabularies).
 
 ## Safety and provenance notes
 
-- Do not treat community posts or hearsay as authoritative. Always link a claim to a verifiable primary source before hard-wiring it into the pipeline.
-- Maintain provenance for any crib added from Sanborn statements: record the quote, source URL, and timestamp so the decision can be audited later.
+- Do not treat community posts or hearsay as authoritative. Always link a claim to a verifiable
+  primary source before hard-wiring it into the pipeline.
+- Maintain provenance for any crib added from Sanborn statements: record the quote, source URL, and
+  timestamp so the decision can be audited later.
 
 ## If you want, I can
 
-- Pull together a first-pass timeline of public Sanborn remarks (I can fetch and summarize sources if you want me to search the web).
-- Generate a crib candidate file from that timeline and run a small scoring sweep with the Berlin-clock and multi-crib transposition stages.
+- Pull together a first-pass timeline of public Sanborn remarks (I can fetch and summarize sources
+  if you want me to search the web).
+- Generate a crib candidate file from that timeline and run a small scoring sweep with the Berlin-
+  clock and multi-crib transposition stages.
 
-Decide whether you want me to fetch primary sources and build the timeline automatically (I can do that next), or if you prefer to review sources manually and I hook them into the pipeline afterwards.
+Decide whether you want me to fetch primary sources and build the timeline automatically (I can do
+that next), or if you prefer to review sources manually and I hook them into the pipeline
+afterwards.

--- a/docs/SANBORN.md
+++ b/docs/SANBORN.md
@@ -11,25 +11,25 @@ museum statement, archived press release, or Sanborn's own website).
 ## High-level, well-established facts
 
 - Jim Sanborn is the artist who created the Kryptos sculpture. The sculpture is installed at the CIA
-  headquarters grounds in Langley, Virginia.
+headquarters grounds in Langley, Virginia.
 - Kryptos is an art piece that intentionally incorporates encrypted text and layered puzzles.
-  Several sections (commonly labelled K1–K3) have been solved publicly; one section (K4) remains
-  widely reported as unsolved.
+Several sections (commonly labelled K1–K3) have been solved publicly; one section (K4) remains
+widely reported as unsolved.
 - Over the years Sanborn has answered questions and given limited clues or clarifications in public
-  interviews, artist statements, and correspondence with the community. He has also been careful
-  about what he releases publicly — many clues are partial and intended to nudge rather than hand
-  over the solution.
+interviews, artist statements, and correspondence with the community. He has also been careful about
+what he releases publicly — many clues are partial and intended to nudge rather than hand over the
+solution.
 
 ## Characteristics of artist-level clues (what to look for)
 
 - The artist often frames context in terms of geography, time, and artifact metaphor: place names,
-  clocks/time references, and directional words appear in the sculpture's plaintext and in reported
-  cribs.
+clocks/time references, and directional words appear in the sculpture's plaintext and in reported
+cribs.
 - Deliberate misspellings and orthographic anomalies appear in solved sections; these are likely
-  part of Sanborn's design language and may repeat as a theme (e.g., nonstandard spellings preserved
-  rather than corrected).
+part of Sanborn's design language and may repeat as a theme (e.g., nonstandard spellings preserved
+rather than corrected).
 - Sanborn's public remarks can be terse and poetic; a seemingly throwaway phrase in an interview may
-  be meant as a hint rather than pure commentary.
+be meant as a hint rather than pure commentary.
 
 ## Research sources to collect (priority order)
 
@@ -45,16 +45,16 @@ sometimes surface overlooked contextual clues.
 ## Practical hypotheses to prioritize for K4 (how artist clues map to cipher hypotheses)
 
 - Time-based keying: any mention of clocks, temporal events, or numerically-encoded times suggests
-  testing key-streams derived from clock encodings (e.g., Berlin Clock / Mengenlehreuhr patterns,
-  historical timestamps).
+testing key-streams derived from clock encodings (e.g., Berlin Clock / Mengenlehreuhr patterns,
+historical timestamps).
 - Geographic and directional anchors: repeated place names (cities, cardinal directions) suggest
-  positional crib bonuses and multi-crib positional transposition stages — prioritize cribs that
-  align to reported indices.
+positional crib bonuses and multi-crib positional transposition stages — prioritize cribs that align
+to reported indices.
 - Intentional misspellings: treat misspellings and anomalies as canonical plaintext rather than
-  noise when scoring and when building crib constraints.
+noise when scoring and when building crib constraints.
 - Artist-supplied words or phrases: when Sanborn mentions words he used in the piece (even in
-  passing), treat those as high-priority cribs but validate their start indices before hard-
-  constraining.
+passing), treat those as high-priority cribs but validate their start indices before hard-
+constraining.
 
 ## Suggested next steps (actionable, reproducible)
 
@@ -73,16 +73,16 @@ to those themes (wordlist filters, domain-specific vocabularies).
 ## Safety and provenance notes
 
 - Do not treat community posts or hearsay as authoritative. Always link a claim to a verifiable
-  primary source before hard-wiring it into the pipeline.
+primary source before hard-wiring it into the pipeline.
 - Maintain provenance for any crib added from Sanborn statements: record the quote, source URL, and
-  timestamp so the decision can be audited later.
+timestamp so the decision can be audited later.
 
 ## If you want, I can
 
 - Pull together a first-pass timeline of public Sanborn remarks (I can fetch and summarize sources
-  if you want me to search the web).
+if you want me to search the web).
 - Generate a crib candidate file from that timeline and run a small scoring sweep with the Berlin-
-  clock and multi-crib transposition stages.
+clock and multi-crib transposition stages.
 
 Decide whether you want me to fetch primary sources and build the timeline automatically (I can do
 that next), or if you prefer to review sources manually and I hook them into the pipeline

--- a/docs/sources/sanborn_crib_candidates.txt
+++ b/docs/sources/sanborn_crib_candidates.txt
@@ -23,7 +23,7 @@ GEOGRAPHY	https://www.cia.gov/legacy/headquarters/kryptos-sculpture/	Agency desc
 # - These are candidate single-word cribs and short contexts intended for
 #   heuristic weighting or seeding search pipelines. Always verify original source
 #   pages before using a crib as a hard constraint in scoring.
- 
+
 TRINITY	https://ahf.nuclearmuseum.org/voices/oral-histories/jim-sanborns-interview	Related to Sanborn's description of Trinity device artifacts (conservative candidate)
 LOSALAMOS	https://ahf.nuclearmuseum.org/voices/oral-histories/jim-sanborns-interview	Sanborn recounts work and artifacts located at Los Alamos
 MANHATTAN	https://ahf.nuclearmuseum.org/voices/oral-histories/jim-sanborns-interview	Context of Manhattan Project installations — potential thematic crib

--- a/docs/sources/sanborn_timeline.md
+++ b/docs/sources/sanborn_timeline.md
@@ -1,12 +1,16 @@
 # Sanborn timeline (working)
-This file is a working timeline of public statements, interviews, and primary sources where Jim Sanborn discusses Kryptos. Fill entries with a short quote, date, and source URL. Use the helper script `scripts/tools/collect_sanborn_sources.py` to fetch and generate entries automatically from a list of URLs.
+This file is a working timeline of public statements, interviews, and primary sources where Jim
+Sanborn discusses Kryptos. Fill entries with a short quote, date, and source URL. Use the helper
+script `scripts/tools/collect_sanborn_sources.py` to fetch and generate entries automatically from a
+list of URLs.
 
 Format (one entry per section):
 
 - Date: YYYY-MM-DD
 - Source: URL
 - Title: Page title or interview name
-If you prefer automatic collection, place a newline-separated list of URLs in `scripts/sources_urls.txt` and run:
+If you prefer automatic collection, place a newline-separated list of URLs in
+`scripts/sources_urls.txt` and run:
 
 ```bash
 python scripts/tools/collect_sanborn_sources.py scripts/sources_urls.txt docs/sources/sanborn_timeline.md
@@ -28,53 +32,76 @@ Example
 
 Automatic collection
 
-If you prefer automatic collection, place a newline-separated list of URLs in `scripts/sources_urls.txt` and run:
+If you prefer automatic collection, place a newline-separated list of URLs in
+`scripts/sources_urls.txt` and run:
 
 ```bash
 python scripts/tools/collect_sanborn_sources.py scripts/sources_urls.txt docs/sources/sanborn_timeline.md
 ```
 
-The script will fetch each URL, extract the title and first paragraph, and append an entry to the timeline. Always manually verify quoted excerpts against the original page before using any crib as a hard constraint.
+The script will fetch each URL, extract the title and first paragraph, and append an entry to the
+timeline. Always manually verify quoted excerpts against the original page before using any crib as
+a hard constraint.
 
 ---
 
 - Date: 2025-08-14
 - Source: [https://en.wikipedia.org/wiki/Jim_Sanborn](https://en.wikipedia.org/wiki/Jim_Sanborn)
 - Title: "Jim Sanborn — Wikipedia"
-- Excerpt: "Herbert James Sanborn, Jr. (born November 14, 1945) is an American sculptor. He is best known for creating the encrypted Kryptos sculpture at CIA headquarters in Langley, Virginia."
-- Notes: Canonical biographical summary and links to primary sources (Smithsonian Archives; interviews). Useful to seed artist-derived crib candidates (e.g., 'BERLIN', 'MAGNETIC', 'PALIMPSEST') and provenance dates. Verify any quoted clue text against the original interviews linked in the references.
+- Excerpt: "Herbert James Sanborn, Jr. (born November 14, 1945) is an American sculptor. He is best
+known for creating the encrypted Kryptos sculpture at CIA headquarters in Langley, Virginia."
+- Notes: Canonical biographical summary and links to primary sources (Smithsonian Archives;
+interviews). Useful to seed artist-derived crib candidates (e.g., 'BERLIN', 'MAGNETIC',
+'PALIMPSEST') and provenance dates. Verify any quoted clue text against the original interviews
+linked in the references.
 
 ---
 
 - Date: 2025-10-21
 - Source: [https://en.wikipedia.org/wiki/Kryptos](https://en.wikipedia.org/wiki/Kryptos)
 - Title: "Kryptos — Wikipedia"
-- Excerpt: "The sculpture comprises four large copper plates... The main sculpture contains four separate enigmatic messages, three of which have been deciphered. The fourth remains one of the world's more famous unsolved codes."
-- Notes: Comprehensive summary of the four encrypted passages, published clues (2010 "BERLIN" clue, 2014 "CLOCK" clue, 2020/2023 NORTHEAST/EAST letters). Highly relevant for crib extraction: coordinates mentioned in passage 2, references to Berlin clock (Mengenlehreuhr), and the keyword hints (PALIMPSEST, ABSCISSA, KRYPTOS).
+- Excerpt: "The sculpture comprises four large copper plates... The main sculpture contains four
+separate enigmatic messages, three of which have been deciphered. The fourth remains one of the
+world's more famous unsolved codes."
+- Notes: Comprehensive summary of the four encrypted passages, published clues (2010 "BERLIN" clue,
+2014 "CLOCK" clue, 2020/2023 NORTHEAST/EAST letters). Highly relevant for crib extraction:
+coordinates mentioned in passage 2, references to Berlin clock (Mengenlehreuhr), and the keyword
+hints (PALIMPSEST, ABSCISSA, KRYPTOS).
 
 ---
 
 - Date: 2025-08-08
 - Source: [https://jimsanborn.net/](https://jimsanborn.net/)
 - Title: "Jim Sanborn Studio (official)"
-- Excerpt: "Public spaces, installations, projections, photos, videos, KRYPTOS — an overview of Sanborn's major public works including Kryptos and related cryptographic pieces."
-- Notes: Official artist site and archive links. Good source for context on Sanborn's intent and the broader set of cryptographic motifs he uses (magnetism, clocks, transposition). Use to expand crib candidate set (words appearing across works and exhibition notes).
+- Excerpt: "Public spaces, installations, projections, photos, videos, KRYPTOS — an overview of
+Sanborn's major public works including Kryptos and related cryptographic pieces."
+- Notes: Official artist site and archive links. Good source for context on Sanborn's intent and the
+broader set of cryptographic motifs he uses (magnetism, clocks, transposition). Use to expand crib
+candidate set (words appearing across works and exhibition notes).
 
 ---
 
 - Date: 2003-06-20
 - Source: [http://www.elonka.com/kryptos/sanborn.html](http://www.elonka.com/kryptos/sanborn.html)
 - Title: "Jim Sanborn: Sculptor, Photographer, Artist (Elonka Dunin)"
-- Excerpt: "Sanborn is probably best known for the 'Kryptos' sculpture installed at CIA Headquarters in 1990, which displays encrypted messages which continue to stump code-breakers to this day."
-- Notes: Fan-curated archive with biographical notes, selected works, and pointers to original interviews and images (useful for provenance and material references like lodestones and Cyrillic Projector).
+- Excerpt: "Sanborn is probably best known for the 'Kryptos' sculpture installed at CIA Headquarters
+in 1990, which displays encrypted messages which continue to stump code-breakers to this day."
+- Notes: Fan-curated archive with biographical notes, selected works, and pointers to original
+interviews and images (useful for provenance and material references like lodestones and Cyrillic
+Projector).
 
 ---
 
 - Date: 2005-01-20
 - Source: [https://www.wired.com/2005/01/questions-for-kryptos-creator/](https://www.wired.com/2005/01/questions-for-kryptos-creator/)
 - Title: "Questions for Kryptos' Creator — Wired" (Kim Zetter interview)
-- Excerpt: "In part of the code that's been deciphered, I refer to an act that took place when I was at the agency and a location that's on the grounds of the agency. So ... you have to decipher the piece and then go to the agency and find that place. There are, for example, longitude and latitude coordinates on the piece, which refer to locations of the agency."
-- Notes: Direct confirmation that the text contains coordinates and references to a specific act/location Sanborn associated with the CIA grounds — strong evidence that geographic/coordinate-derived cribs or place-names are relevant.
+- Excerpt: "In part of the code that's been deciphered, I refer to an act that took place when I was
+at the agency and a location that's on the grounds of the agency. So ... you have to decipher the
+piece and then go to the agency and find that place. There are, for example, longitude and latitude
+coordinates on the piece, which refer to locations of the agency."
+- Notes: Direct confirmation that the text contains coordinates and references to a specific
+act/location Sanborn associated with the CIA grounds — strong evidence that geographic/coordinate-
+derived cribs or place-names are relevant.
 
 ---
 
@@ -82,7 +109,9 @@ The script will fetch each URL, extract the title and first paragraph, and appen
 - Source: [https://www.wired.com/2005/01/questions-for-kryptos-creator/](https://www.wired.com/2005/01/questions-for-kryptos-creator/)
 - Title: "Questions for Kryptos' Creator — Wired" (Kim Zetter interview)
 - Excerpt: "I made reference in the encoded text to something I could have carried out."
-- Notes: Sanborn acknowledges that a referenced 'act' in the text could have been carried out by him — implies literal actions described on the sculpture may map to instructions or positional clues (useful for interpreting verbs/commands in K4).
+- Notes: Sanborn acknowledges that a referenced 'act' in the text could have been carried out by him
+— implies literal actions described on the sculpture may map to instructions or positional clues
+(useful for interpreting verbs/commands in K4).
 
 ---
 
@@ -90,42 +119,62 @@ The script will fetch each URL, extract the title and first paragraph, and appen
 - Source: [https://www.wired.com/2005/01/questions-for-kryptos-creator/](https://www.wired.com/2005/01/questions-for-kryptos-creator/)
 - Title: "Questions for Kryptos' Creator — Wired" (Kim Zetter interview)
 - Excerpt: "I would think five or six." (asked how many cryptographic techniques he used)
-- Notes: Sanborn's estimate of the number of techniques ("five or six") is a confirmed clue about cipher complexity — suggests K4 combines multiple layered encipherment strategies.
+- Notes: Sanborn's estimate of the number of techniques ("five or six") is a confirmed clue about
+cipher complexity — suggests K4 combines multiple layered encipherment strategies.
 
 ---
 
 - Date: 1990-11-03
 - Source: [https://www.cia.gov/legacy/headquarters/kryptos-sculpture/](https://www.cia.gov/legacy/headquarters/kryptos-sculpture/)
 - Title: "\"Kryptos\" Sculpture — CIA"
-- Excerpt: "James Sanborn once said, 'They will be able to read what I wrote, but what I wrote is a mystery itself.'"
-- Notes: Direct artist quotation published in the agency's official description — confirms Sanborn's intent to create layered ambiguity and supports cautious use of literal-sense cribs (surface-readable phrases may be metaphorical).
+- Excerpt: "James Sanborn once said, 'They will be able to read what I wrote, but what I wrote is a
+mystery itself.'"
+- Notes: Direct artist quotation published in the agency's official description — confirms Sanborn's
+intent to create layered ambiguity and supports cautious use of literal-sense cribs (surface-
+readable phrases may be metaphorical).
 
 ---
 
 - Date: 1990-11-03
 - Source: [https://www.cia.gov/legacy/headquarters/kryptos-sculpture/](https://www.cia.gov/legacy/headquarters/kryptos-sculpture/)
 - Title: "\"Kryptos\" Sculpture — CIA"
-- Excerpt: "I gave it to William Webster at the dedication ceremony with a wax seal on it, but in fact I really didn't tell him the whole story. I definitely didn't give him the last section, which has never been deciphered."
-- Notes: Sanborn's admission about the dedication envelope and deliberately withholding K4 confirms there is a canonical solution record and that the final section was intentionally kept secret from the Agency director — reinforces that verification rests with the artist and that certain referents (e.g., 'WW' -> William Webster) are authoritatively confirmed.
+- Excerpt: "I gave it to William Webster at the dedication ceremony with a wax seal on it, but in
+fact I really didn't tell him the whole story. I definitely didn't give him the last section, which
+has never been deciphered."
+- Notes: Sanborn's admission about the dedication envelope and deliberately withholding K4 confirms
+there is a canonical solution record and that the final section was intentionally kept secret from
+the Agency director — reinforces that verification rests with the artist and that certain referents
+(e.g., 'WW' -> William Webster) are authoritatively confirmed.
 
 - Date: 1990-11-03
 - Source: [https://www.cia.gov/legacy/headquarters/kryptos-sculpture/](https://www.cia.gov/legacy/headquarters/kryptos-sculpture/)
 - Title: "\"Kryptos\" Sculpture — CIA"
-- Excerpt: "The theme of this sculpture is 'intelligence gathering.' It was dedicated on Nov. 3, 1990... The copperplate screen has exactly 1,735 alphabetic letters cut into it."
-- Notes: Official agency page describing materials (petrified wood, lodestone, copper), the intention (intelligence gathering), and public history. Good for surface-level provenance and the Agency's account of solved passages.
+- Excerpt: "The theme of this sculpture is 'intelligence gathering.' It was dedicated on Nov. 3,
+1990... The copperplate screen has exactly 1,735 alphabetic letters cut into it."
+- Notes: Official agency page describing materials (petrified wood, lodestone, copper), the
+intention (intelligence gathering), and public history. Good for surface-level provenance and the
+Agency's account of solved passages.
 
 ---
 
 - Date: 2005-01-20
 - Source: [https://www.wired.com/2005/01/questions-for-kryptos-creator/](https://www.wired.com/2005/01/questions-for-kryptos-creator/)
 - Title: "Questions for Kryptos' Creator — Wired"
-- Excerpt: "For the student of cryptography it's always helpful to gather as much information as possible when zeroing in on and encoding a system... I made reference in the encoded text to something I could have carried out."
-- Notes: Interview transcript with Jim Sanborn (Kim Zetter). Contains several first-person statements about intent, use of lodestones, references to coordinate clues and staged difficulty across the courtyard pieces — high-value for crib/context generation.
+- Excerpt: "For the student of cryptography it's always helpful to gather as much information as
+possible when zeroing in on and encoding a system... I made reference in the encoded text to
+something I could have carried out."
+- Notes: Interview transcript with Jim Sanborn (Kim Zetter). Contains several first-person
+statements about intent, use of lodestones, references to coordinate clues and staged difficulty
+across the courtyard pieces — high-value for crib/context generation.
 
 ---
 
 - Date: 2009-07-14
 - Source: https://www.aaa.si.edu/collections/interviews/oral-history-interview-jim-sanborn-15700
 - Title: "Oral history interview with Jim Sanborn, 2009 Jul 14-16"
-- Excerpt: Transcript available from the Archives of American Art (Avis Berman interview). Usage conditions apply; the transcript contains first-person recollections about the commissioning and conceptualization of Kryptos and related public commissions.
-- Notes: Primary-source oral-history transcript — consult the Archives of American Art transcript for direct quotes (downloadable PDF). This record supports adding historically-grounded crib candidates but the transcript has usage restrictions; only metadata added here.
+- Excerpt: Transcript available from the Archives of American Art (Avis Berman interview). Usage
+conditions apply; the transcript contains first-person recollections about the commissioning and
+conceptualization of Kryptos and related public commissions.
+- Notes: Primary-source oral-history transcript — consult the Archives of American Art transcript
+for direct quotes (downloadable PDF). This record supports adding historically-grounded crib
+candidates but the transcript has usage restrictions; only metadata added here.

--- a/examples/sample_composite_run.py
+++ b/examples/sample_composite_run.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 try:
-    from src.k4 import (
+    from kryptos.src.k4 import (
         make_berlin_clock_stage,
         make_hill_constraint_stage,
         make_masking_stage,
@@ -16,10 +16,7 @@ try:
         persist_attempt_logs,
         run_composite_pipeline,
     )
-except ImportError:  # fallback for direct script execution without install
-    PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    if PROJECT_ROOT not in sys.path:
-        sys.path.insert(0, PROJECT_ROOT)
+except Exception:
     try:
         from src.k4 import (
             make_berlin_clock_stage,
@@ -30,11 +27,27 @@ except ImportError:  # fallback for direct script execution without install
             persist_attempt_logs,
             run_composite_pipeline,
         )
-    except ImportError as e:
-        raise ImportError(
-            f"Failed to import 'src.k4' even after adding PROJECT_ROOT to sys.path. "
-            f"Ensure the package is installed or the source is available at '{PROJECT_ROOT}'.\nOriginal error: {e}",
-        ) from e
+    except Exception:
+        PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        if PROJECT_ROOT not in sys.path:
+            sys.path.insert(0, PROJECT_ROOT)
+        try:
+            from src.k4 import (
+                make_berlin_clock_stage,
+                make_hill_constraint_stage,
+                make_masking_stage,
+                make_transposition_adaptive_stage,
+                make_transposition_multi_crib_stage,
+                persist_attempt_logs,
+                run_composite_pipeline,
+            )
+        except ImportError as e2:
+            msg = (
+                "Failed to import 'src.k4' even after adding PROJECT_ROOT to sys.path. "
+                f"Ensure the package is installed or the source is available at '{PROJECT_ROOT}'.\n"
+                f"Original error: {e2}"
+            )
+            raise ImportError(msg) from e2
 from collections.abc import Sequence
 
 CIPHER_K4 = "OBKRUOXOGHULBSOLIFBBWFLRVQQPRNGKSSOTWTQSJQSSEKZZWATJKLUDIAWINFBNYPVTTMZFPKWGDKZXTJCDIGKUHUAUEKCAR"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,22 @@ ignore = ["E203"]
 quote-style = "preserve"
 indent-style = "space"
 line-ending = "auto"
+
+[build-system]
+requires = ["setuptools>=61.0","wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kryptos"
+version = "0.0.0"
+description = "Kryptos tooling and autopilot harness"
+authors = [ { name = "nitsuah" } ]
+readme = "README.md"
+license = { text = "MIT" }
+keywords = ["kryptos","autopilot","crypto"]
+classifiers = [
+	"Programming Language :: Python :: 3",
+	"License :: OSI Approved :: MIT License",
+	"Operating System :: OS Independent",
+]
+packages = ["kryptos"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kryptos"
-version = "0.0.0"
+version = "0.0.1"
 description = "Kryptos tooling and autopilot harness"
 authors = [ { name = "nitsuah" } ]
 readme = "README.md"
@@ -28,4 +28,6 @@ classifiers = [
 	"License :: OSI Approved :: MIT License",
 	"Operating System :: OS Independent",
 ]
-packages = ["kryptos"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flake8
 pytest
 pytest-cov
 pre-commit
+requests

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,8 +1,7 @@
-K4 demo
-=======
+K4 demo =======
 
-This folder contains a tiny demo runner that exercises a short K4 composite pipeline
-and writes artifacts under `artifacts/demo/run_<ts>/`.
+This folder contains a tiny demo runner that exercises a short K4 composite pipeline and writes
+artifacts under `artifacts/demo/run_<ts>/`.
 
 Usage (local):
 

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,0 +1,13 @@
+K4 demo
+=======
+
+This folder contains a tiny demo runner that exercises a short K4 composite pipeline
+and writes artifacts under `artifacts/demo/run_<ts>/`.
+
+Usage (local):
+
+```pwsh
+python scripts/demo/run_k4_demo.py --limit 10
+```
+
+The demo is intentionally small and fast so it can be run in CI or locally without heavy compute.

--- a/scripts/demo/run_k4_demo.py
+++ b/scripts/demo/run_k4_demo.py
@@ -1,0 +1,58 @@
+"""Tiny K4 demo runner.
+
+Runs a short, fast composite pipeline using existing stage factories in src.k4
+and writes artifacts under artifacts/demo/run_<ts>/.
+
+This is intended to be fast and safe for CI/local experimentation.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def run_demo(limit: int = 10):
+    # try to import from src.k4; make-work if not installed
+    try:
+        from src.k4 import make_hill_constraint_stage, make_masking_stage, persist_attempt_logs, run_composite_pipeline
+    except Exception:
+        PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+        if PROJECT_ROOT not in sys.path:
+            sys.path.insert(0, PROJECT_ROOT)
+        from src.k4 import make_hill_constraint_stage, make_masking_stage, persist_attempt_logs, run_composite_pipeline
+
+    # tiny cipher and minimal stages for demo speed
+    CIPHER = 'OBKRUOXOGHULBSOLIFBBWFLRVQQPRNGKSSOTW'
+    stages = [make_hill_constraint_stage(partial_len=30, partial_min=-200.0), make_masking_stage(limit=5)]
+
+    weights = None
+    run_composite_pipeline(
+        CIPHER,
+        stages,
+        report=False,
+        weights=weights,
+        normalize=True,
+        adaptive=False,
+        limit=limit,
+    )
+
+    ts = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+    out_dir = Path('artifacts') / 'demo' / f'run_{ts}'
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # persist attempt logs into the demo directory
+    persist_attempt_logs(out_dir=str(out_dir), label='K4-DEMO', clear=False)
+    print('Demo complete. Artifacts written to:', out_dir)
+    return str(out_dir)
+
+
+if __name__ == '__main__':
+    import argparse
+
+    p = argparse.ArgumentParser(description='Run a tiny K4 demo pipeline')
+    p.add_argument('--limit', type=int, default=10, help='Result limit to produce')
+    args = p.parse_args()
+    run_demo(limit=args.limit)

--- a/scripts/demo/run_k4_demo.py
+++ b/scripts/demo/run_k4_demo.py
@@ -15,22 +15,40 @@ from pathlib import Path
 
 
 def run_demo(limit: int = 10):
-    # try to import from src.k4; make-work if not installed
+    # Prefer installed package import, fall back to src/ in workspace or adding project root
     try:
-        from src.k4 import make_hill_constraint_stage, make_masking_stage, persist_attempt_logs, run_composite_pipeline
-    except Exception:
-        PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-        if PROJECT_ROOT not in sys.path:
-            sys.path.insert(0, PROJECT_ROOT)
-        from src.k4 import make_hill_constraint_stage, make_masking_stage, persist_attempt_logs, run_composite_pipeline
+        from kryptos.src.k4 import (
+            make_hill_constraint_stage,
+            make_masking_stage,
+            persist_attempt_logs,
+            run_composite_pipeline,
+        )
+    except ImportError:
+        try:
+            from src.k4 import (
+                make_hill_constraint_stage,
+                make_masking_stage,
+                persist_attempt_logs,
+                run_composite_pipeline,
+            )
+        except ImportError:
+            PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+            if PROJECT_ROOT not in sys.path:
+                sys.path.insert(0, PROJECT_ROOT)
+            from src.k4 import (
+                make_hill_constraint_stage,
+                make_masking_stage,
+                persist_attempt_logs,
+                run_composite_pipeline,
+            )
 
     # tiny cipher and minimal stages for demo speed
-    CIPHER = 'OBKRUOXOGHULBSOLIFBBWFLRVQQPRNGKSSOTW'
+    cipher = 'OBKRUOXOGHULBSOLIFBBWFLRVQQPRNGKSSOTW'
     stages = [make_hill_constraint_stage(partial_len=30, partial_min=-200.0), make_masking_stage(limit=5)]
 
     weights = None
     run_composite_pipeline(
-        CIPHER,
+        cipher,
         stages,
         report=False,
         weights=weights,

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -1,0 +1,55 @@
+# Autopilot dev README
+
+This small README explains the local "autopilot" flow and how the SPY extractor threshold is chosen.
+
+## Overview
+
+- The autopilot orchestrator runs three logical components: Q (question/planner), OPS (operational tuner/sweep), and SPY (conservative crib extractor).
+- `scripts/dev/ask_triumverate.py` is a small driver that can run the autopilot loop in dry-run or full-auto.
+
+## SPY threshold selection
+
+- The SPY extractor accepts a minimum confidence threshold via the environment variable `SPY_MIN_CONF` or CLI `--min-conf`.
+- If `SPY_MIN_CONF` is not set, the autopilot will call the SPY evaluation harness to compute a recommended threshold from labeled tuning runs.
+- The evaluation harness lives at `kryptos/scripts/tuning/spy_eval.py` and evaluates precision/recall/F1 across thresholds.
+- By default the harness now prefers a threshold that maximizes precision (conservative extraction). If multiple thresholds have identical precision, it picks the one with the higher F1 score as a tie-breaker.
+
+## Running locally
+
+- To run the autopilot in dry-run mode:
+
+```powershell
+Set-Location 'C:\Users\<you>\code\kryptos'
+python scripts/dev/ask_triumverate.py --dry-run
+```
+
+- To run full autopilot and allow SPY to run automatically (writes to `agents/LEARNED.md`):
+
+```powershell
+python scripts/dev/ask_triumverate.py
+```
+
+- To override the computed threshold explicitly:
+
+```powershell
+$env:SPY_MIN_CONF = '0.5'
+python scripts/dev/ask_triumverate.py
+```
+
+## Local editable install (recommended for development)
+
+Install the project in editable mode so imports like `kryptos.scripts.tuning.spy_eval` resolve consistently:
+
+```powershell
+Set-Location 'C:\Users\<you>\code\kryptos'
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install -e .
+```
+
+After that you can run tests and demos normally (pytest, demo runner, etc.).
+
+## Notes
+
+- The evaluation harness expects labeled CSV in `data/spy_eval_labels.csv` with rows `run_dir,token` and tuning runs under `artifacts/tuning_runs/run_<ts>/`.
+- If you prefer to bias threshold selection to maximize recall (less conservative), we can change the selection strategy in `kryptos/scripts/tuning/spy_eval.py`.

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -4,15 +4,22 @@ This small README explains the local "autopilot" flow and how the SPY extractor 
 
 ## Overview
 
-- The autopilot orchestrator runs three logical components: Q (question/planner), OPS (operational tuner/sweep), and SPY (conservative crib extractor).
-- `scripts/dev/ask_triumverate.py` is a small driver that can run the autopilot loop in dry-run or full-auto.
+- The autopilot orchestrator runs three logical components: Q (question/planner), OPS (operational
+tuner/sweep), and SPY (conservative crib extractor).
+- `scripts/dev/ask_triumverate.py` is a small driver that can run the autopilot loop in dry-run or
+full-auto.
 
 ## SPY threshold selection
 
-- The SPY extractor accepts a minimum confidence threshold via the environment variable `SPY_MIN_CONF` or CLI `--min-conf`.
-- If `SPY_MIN_CONF` is not set, the autopilot will call the SPY evaluation harness to compute a recommended threshold from labeled tuning runs.
-- The evaluation harness lives at `kryptos/scripts/tuning/spy_eval.py` and evaluates precision/recall/F1 across thresholds.
-- By default the harness now prefers a threshold that maximizes precision (conservative extraction). If multiple thresholds have identical precision, it picks the one with the higher F1 score as a tie-breaker.
+- The SPY extractor accepts a minimum confidence threshold via the environment variable
+`SPY_MIN_CONF` or CLI `--min-conf`.
+- If `SPY_MIN_CONF` is not set, the autopilot will call the SPY evaluation harness to compute a
+recommended threshold from labeled tuning runs.
+- The evaluation harness lives at `kryptos/scripts/tuning/spy_eval.py` and evaluates
+precision/recall/F1 across thresholds.
+- By default the harness now prefers a threshold that maximizes precision (conservative extraction).
+If multiple thresholds have identical precision, it picks the one with the higher F1 score as a tie-
+breaker.
 
 ## Running locally
 
@@ -38,7 +45,8 @@ python scripts/dev/ask_triumverate.py
 
 ## Local editable install (recommended for development)
 
-Install the project in editable mode so imports like `kryptos.scripts.tuning.spy_eval` resolve consistently:
+Install the project in editable mode so imports like `kryptos.scripts.tuning.spy_eval` resolve
+consistently:
 
 ```powershell
 Set-Location 'C:\Users\<you>\code\kryptos'
@@ -51,5 +59,7 @@ After that you can run tests and demos normally (pytest, demo runner, etc.).
 
 ## Notes
 
-- The evaluation harness expects labeled CSV in `data/spy_eval_labels.csv` with rows `run_dir,token` and tuning runs under `artifacts/tuning_runs/run_<ts>/`.
-- If you prefer to bias threshold selection to maximize recall (less conservative), we can change the selection strategy in `kryptos/scripts/tuning/spy_eval.py`.
+- The evaluation harness expects labeled CSV in `data/spy_eval_labels.csv` with rows `run_dir,token`
+and tuning runs under `artifacts/tuning_runs/run_<ts>/`.
+- If you prefer to bias threshold selection to maximize recall (less conservative), we can change
+the selection strategy in `kryptos/scripts/tuning/spy_eval.py`.

--- a/scripts/dev/README_pr.md
+++ b/scripts/dev/README_pr.md
@@ -1,0 +1,34 @@
+# Creating PRs from CI or locally
+
+Two options to create PRs programmatically:
+
+- Use GitHub CLI (`gh`) — convenient and interactive. Install from https://cli.github.com/ and run `gh auth login`.
+- Use REST API with a token: set `GITHUB_TOKEN` environment variable (needs `repo` scope for private repos) and use `scripts/dev/create_pr.py`.
+
+Examples:
+
+```powershell
+# with gh (recommended locally):
+gh pr create --fill --web
+
+# with token (CI):
+$env:GITHUB_TOKEN = 'ghp_...'
+python .\scripts\dev\create_pr.py --head autopilot/triumverate-20251022T212638 --title "WIP: autopilot" --body "Creates autopilot branch"
+```
+Creating PRs from CI or locally
+
+Two options to create PRs programmatically:
+
+- Use GitHub CLI (`gh`) — convenient and interactive. Install from https://cli.github.com/ and run `gh auth login`.
+- Use REST API with a token: set `GITHUB_TOKEN` environment variable (needs `repo` scope for private repos) and use `scripts/dev/create_pr.py`.
+
+Examples:
+
+```powershell
+# with gh (recommended locally):
+gh pr create --fill --web
+
+# with token (CI):
+$env:GITHUB_TOKEN = 'ghp_...'
+python .\scripts\dev\create_pr.py --head autopilot/triumverate-20251022T212638 --title "WIP: autopilot" --body "Creates autopilot branch"
+```

--- a/scripts/dev/README_pr.md
+++ b/scripts/dev/README_pr.md
@@ -3,7 +3,8 @@
 Two options to create PRs programmatically:
 
 - Use GitHub CLI (`gh`) — convenient and interactive. Install from https://cli.github.com/ and run `gh auth login`.
-- Use REST API with a token: set `GITHUB_TOKEN` environment variable (needs `repo` scope for private repos) and use `scripts/dev/create_pr.py`.
+- Use REST API with a token: set `GITHUB_TOKEN` environment variable (needs `repo` scope for private
+repos) and use `scripts/dev/create_pr.py`.
 
 Examples:
 
@@ -20,7 +21,8 @@ Creating PRs from CI or locally
 Two options to create PRs programmatically:
 
 - Use GitHub CLI (`gh`) — convenient and interactive. Install from https://cli.github.com/ and run `gh auth login`.
-- Use REST API with a token: set `GITHUB_TOKEN` environment variable (needs `repo` scope for private repos) and use `scripts/dev/create_pr.py`.
+- Use REST API with a token: set `GITHUB_TOKEN` environment variable (needs `repo` scope for private
+repos) and use `scripts/dev/create_pr.py`.
 
 Examples:
 

--- a/scripts/dev/ask_best_next.py
+++ b/scripts/dev/ask_best_next.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 
 def main() -> None:
+    """Ask the triumverate for the best next action."""
     os.environ['PLAN'] = (
         "Please review the current repository status and recommend the single best next action:"
         " options: (1) push the 'cribs-sanborn' branch and open a PR, (2) finish OPS automation so the"
@@ -11,11 +12,14 @@ def main() -> None:
         " Provide a 1-line recommendation and one sentence justification."
     )
 
-    # ensure repo root is on sys.path
-    repo = Path(__file__).resolve().parents[2]
-    sys.path.insert(0, str(repo))
-
-    from scripts.dev.ask_triumverate import run_plan_check
+    # Prefer package import; fall back to inserting repo root on sys.path
+    try:
+        from kryptos.scripts.dev.ask_triumverate import run_plan_check
+    except Exception:
+        repo = Path(__file__).resolve().parents[2]
+        if str(repo) not in sys.path:
+            sys.path.insert(0, str(repo))
+        from scripts.dev.ask_triumverate import run_plan_check
 
     print('Asking triumverate for best next action...')
     run_plan_check(os.environ['PLAN'])

--- a/scripts/dev/ask_triumverate.py
+++ b/scripts/dev/ask_triumverate.py
@@ -41,7 +41,7 @@ def run_plan_check(
         # Execute a small set of safe, idempotent actions automatically when recommended.
         rec_lower = rec.lower()
         # If triumverate wants an OPS run and ops_run_tuning is available, run it.
-        if 'ops' in rec_lower or 'run' in rec_lower and 'crib' in rec_lower:
+        if 'ops' in rec_lower or ('run' in rec_lower and 'crib' in rec_lower):
             if hasattr(orch, 'ops_run_tuning'):
                 try:
                     print(f"[AUTOPILOT] Executing recommended OPS run (dry_run={dry_run})...")

--- a/scripts/dev/ask_triumverate.py
+++ b/scripts/dev/ask_triumverate.py
@@ -55,7 +55,9 @@ def run_plan_check(
                             import sys
 
                             try:
-                                subprocess.check_call([sys.executable, str(spy_path)])
+                                # allow configuring a conservative min confidence via env
+                                min_conf = os.environ.get('SPY_MIN_CONF', '0.25')
+                                subprocess.check_call([sys.executable, str(spy_path), '--min-conf', str(min_conf)])
                                 print('[AUTOPILOT] SPY extractor completed')
                             except Exception as e:
                                 print(f"[AUTOPILOT] SPY extractor failed: {e}")
@@ -123,7 +125,8 @@ def run_plan_check(
                             import sys
 
                             print('Invoking SPY extractor on run artifacts...')
-                            subprocess.check_call([sys.executable, str(spy_path)])
+                            min_conf = os.environ.get('SPY_MIN_CONF', '0.25')
+                            subprocess.check_call([sys.executable, str(spy_path), '--min-conf', str(min_conf)])
                             print('SPY extractor completed')
                         except Exception as e:
                             print(f'SPY extractor failed: {e}')

--- a/scripts/dev/ask_triumverate.py
+++ b/scripts/dev/ask_triumverate.py
@@ -145,6 +145,24 @@ def run_plan_check(
         print(ln.strip())
 
 
+def _parse_weights(s: str | None) -> list[float] | None:
+    if not s:
+        return None
+    try:
+        return [float(x.strip()) for x in s.split(',') if x.strip()]
+    except Exception:
+        return None
+
+
 if __name__ == "__main__":
-    plan = os.environ.get("PLAN", None)
-    run_plan_check(plan)
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Autopilot triumverate runner')
+    parser.add_argument('--plan', type=str, default=None, help='Plan text to append to Q prompt')
+    parser.add_argument('--weights', type=str, default=None, help='Comma-separated weights to pass to OPS')
+    parser.add_argument('--dry-run', dest='dry_run', action='store_true', help='Run OPS in dry-run mode')
+    parser.add_argument('--no-autopilot', dest='autopilot', action='store_false', help="Don't auto-query triumverate")
+    args = parser.parse_args()
+
+    weights = _parse_weights(args.weights)
+    run_plan_check(args.plan, autopilot=args.autopilot, weights=weights, dry_run=args.dry_run)

--- a/scripts/dev/ask_triumverate.py
+++ b/scripts/dev/ask_triumverate.py
@@ -56,7 +56,17 @@ def run_plan_check(
 
                             try:
                                 # allow configuring a conservative min confidence via env
-                                min_conf = os.environ.get('SPY_MIN_CONF', '0.25')
+                                min_conf = os.environ.get('SPY_MIN_CONF')
+                                if not min_conf:
+                                    # compute best threshold from any available labels/runs
+                                    try:
+                                        from scripts.tuning import spy_eval
+
+                                        labels = Path('data') / 'spy_eval_labels.csv'
+                                        runs = Path('artifacts') / 'tuning_runs'
+                                        min_conf = str(spy_eval.select_best_threshold(labels, runs))
+                                    except Exception:
+                                        min_conf = '0.25'
                                 subprocess.check_call([sys.executable, str(spy_path), '--min-conf', str(min_conf)])
                                 print('[AUTOPILOT] SPY extractor completed')
                             except Exception as e:
@@ -125,7 +135,16 @@ def run_plan_check(
                             import sys
 
                             print('Invoking SPY extractor on run artifacts...')
-                            min_conf = os.environ.get('SPY_MIN_CONF', '0.25')
+                            min_conf = os.environ.get('SPY_MIN_CONF')
+                            if not min_conf:
+                                try:
+                                    from scripts.tuning import spy_eval
+
+                                    labels = Path('data') / 'spy_eval_labels.csv'
+                                    runs = Path('artifacts') / 'tuning_runs'
+                                    min_conf = str(spy_eval.select_best_threshold(labels, runs))
+                                except Exception:
+                                    min_conf = '0.25'
                             subprocess.check_call([sys.executable, str(spy_path), '--min-conf', str(min_conf)])
                             print('SPY extractor completed')
                         except Exception as e:

--- a/scripts/dev/ask_triumverate.py
+++ b/scripts/dev/ask_triumverate.py
@@ -23,7 +23,12 @@ def load_orchestrator():
     raise RuntimeError(f"Failed to load orchestrator at {orch_path}")
 
 
-def run_plan_check(plan_text: str | None = None, autopilot: bool = True):
+def run_plan_check(
+    plan_text: str | None = None,
+    autopilot: bool = True,
+    weights: list[float] | None = None,
+    dry_run: bool = True,
+):
     orch = load_orchestrator()
     personas = orch.load_personas()
 
@@ -35,12 +40,12 @@ def run_plan_check(plan_text: str | None = None, autopilot: bool = True):
 
         # Execute a small set of safe, idempotent actions automatically when recommended.
         rec_lower = rec.lower()
-        # If triumverate wants an OPS run and ops_run_tuning is available, run it (dry-run).
+        # If triumverate wants an OPS run and ops_run_tuning is available, run it.
         if 'ops' in rec_lower or 'run' in rec_lower and 'crib' in rec_lower:
             if hasattr(orch, 'ops_run_tuning'):
                 try:
-                    print('[AUTOPILOT] Executing recommended OPS run (dry-run)...')
-                    run_path = orch.ops_run_tuning(dry_run=True)
+                    print(f"[AUTOPILOT] Executing recommended OPS run (dry_run={dry_run})...")
+                    run_path = orch.ops_run_tuning(weights=weights, dry_run=dry_run)
                     if run_path:
                         print(f"[AUTOPILOT] OPS wrote tuning artifacts to: {run_path}")
                         # run SPY extractor automatically if present

--- a/scripts/dev/create_pr.py
+++ b/scripts/dev/create_pr.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Small helper to create a GitHub PR via REST API using a personal access token.
+
+Usage:
+  export GITHUB_TOKEN=ghp_...
+  python scripts/dev/create_pr.py --head autopilot/branch --base main --title "WIP" --body "PR body"
+
+This script is a fallback when the `gh` CLI isn't available. It requires a token with
+`repo` scope for private repos or `public_repo` for public repos.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import requests
+
+
+def create_pr(
+    owner: str,
+    repo: str,
+    head: str,
+    base: str = 'main',
+    title: str = '',
+    body: str = '',
+    token: str | None = None,
+) -> dict:
+    """Create a PR via GitHub REST API and return the parsed JSON response.
+
+    Raises ValueError if token is not provided.
+    Raises requests.HTTPError on non-2xx responses.
+    """
+    if not token:
+        token = os.environ.get('GITHUB_TOKEN')
+    if not token:
+        raise ValueError('GITHUB_TOKEN required to create a PR programmatically')
+
+    url = f'https://api.github.com/repos/{owner}/{repo}/pulls'
+    headers = {
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github.v3+json',
+    }
+    payload = {
+        'title': title or f'PR: {head} -> {base}',
+        'head': head,
+        'base': base,
+        'body': body,
+    }
+    resp = requests.post(url, headers=headers, json=payload, timeout=15)
+    if not resp.ok:
+        # raise with helpful message
+        try:
+            msg = resp.json()
+        except Exception:
+            msg = resp.text
+        raise requests.HTTPError(f'Failed to create PR: {resp.status_code} {msg}')
+    return resp.json()
+
+
+def _parse_repo(origin_url: str) -> tuple[str, str]:
+    # Normalize origin url into owner/repo
+    if origin_url.endswith('.git'):
+        origin_url = origin_url[:-4]
+    if origin_url.startswith('git@'):
+        # git@github.com:owner/repo.git
+        origin_url = origin_url.replace(':', '/').replace('git@', 'https://')
+    # now expect https://.../owner/repo
+    parts = origin_url.rstrip('/').split('/')
+    if len(parts) < 2:
+        raise ValueError('Cannot parse origin url')
+    return parts[-2], parts[-1]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--origin', type=str, default=None, help='origin URL (optional)')
+    parser.add_argument('--head', type=str, required=True, help='head branch (owner:branch or branch)')
+    parser.add_argument('--base', type=str, default='main', help='base branch')
+    parser.add_argument('--title', type=str, default='', help='PR title')
+    parser.add_argument('--body', type=str, default='', help='PR body')
+    parser.add_argument(
+        '--token',
+        type=str,
+        default=None,
+        help=('GitHub token (optional, env GITHUB_TOKEN will be used if omitted)'),
+    )
+    args = parser.parse_args(argv)
+
+    # try to infer owner/repo from git remote if not provided
+    origin = args.origin or os.environ.get('GIT_REMOTE_ORIGIN')
+    if not origin:
+        # try to read via git command
+        try:
+            import subprocess
+
+            origin = subprocess.check_output(['git', 'remote', 'get-url', 'origin'], encoding='utf-8').strip()
+        except Exception:
+            origin = None
+
+    if not origin:
+        print('Cannot determine repo owner/repo. Set --origin or GIT_REMOTE_ORIGIN environment variable.')
+        return 2
+
+    try:
+        owner, repo = _parse_repo(origin)
+    except Exception as e:
+        print(f'Failed to parse origin URL: {e}')
+        return 2
+
+    try:
+        res = create_pr(owner, repo, head=args.head, base=args.base, title=args.title, body=args.body, token=args.token)
+        print('PR created:', res.get('html_url'))
+        return 0
+    except Exception as e:
+        print('PR creation failed:', e)
+        # print fallback compare URL
+        compare = f"{origin}/compare/{args.base}...{args.head}?expand=1"
+        print('Fallback compare URL:', compare)
+        return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/dev/orchestrator.py
+++ b/scripts/dev/orchestrator.py
@@ -94,8 +94,11 @@ def recommend_next_action() -> tuple[str, str]:
     # detect a simple SPY extractor presence
     spy_extractor_path = os.path.join(repo_root, 'scripts', 'dev', 'spy_extractor.py')
     has_spy = os.path.exists(spy_extractor_path)
-    # detect ops_run_tuning presence
-    has_ops = hasattr(sys.modules.get(__name__), 'ops_run_tuning')
+    # detect ops_run_tuning presence: prefer an in-module callable or the presence of the sweep script
+    has_ops = callable(globals().get('ops_run_tuning'))
+    if not has_ops:
+        sweep_script = os.path.join(repo_root, 'scripts', 'tuning', 'crib_weight_sweep.py')
+        has_ops = os.path.exists(sweep_script)
 
     if not has_ops:
         return (

--- a/scripts/dev/orchestrator.py
+++ b/scripts/dev/orchestrator.py
@@ -118,7 +118,12 @@ def recommend_next_action() -> tuple[str, str]:
     )
 
 
-def ops_run_tuning(weights: list[float] | None = None, dry_run: bool = True) -> str:
+def ops_run_tuning(
+    weights: list[float] | None = None,
+    dry_run: bool = True,
+    retries: int = 3,
+    backoff_factor: float = 0.5,
+) -> str | dict:
     """Run the crib_weight_sweep script programmatically.
 
     Returns the run directory path as a string. By default this is a dry run (no network or external
@@ -141,8 +146,7 @@ def ops_run_tuning(weights: list[float] | None = None, dry_run: bool = True) -> 
     # run the external script; it will write artifacts under artifacts/tuning_runs/
     # implement retries with exponential backoff for transient failures
     attempts = 0
-    max_retries = 3
-    backoff_factor = 0.5
+    max_retries = int(retries)
     while True:
         try:
             attempts += 1
@@ -154,7 +158,7 @@ def ops_run_tuning(weights: list[float] | None = None, dry_run: bool = True) -> 
             if attempts >= max_retries:
                 print(f"ops_run_tuning: exceeded max retries ({max_retries}), aborting")
                 return ''
-            sleep_for = backoff_factor * (2 ** (attempts - 1))
+            sleep_for = float(backoff_factor) * (2 ** (attempts - 1))
             print(f"ops_run_tuning: sleeping {sleep_for:.2f}s before retry")
             time.sleep(sleep_for)
 
@@ -164,8 +168,36 @@ def ops_run_tuning(weights: list[float] | None = None, dry_run: bool = True) -> 
     runs = [p for p in tr_dir.iterdir() if p.is_dir() and p.name.startswith('run_')]
     if not runs:
         return ''
-    latest = max(runs, key=lambda p: p.stat().st_mtime)
-    return str(latest)
+    # prefer runs that contain the primary sweep csv artifact
+    runs_with_csv = [p for p in runs if (p / 'crib_weight_sweep.csv').exists()]
+    if runs_with_csv:
+        latest = max(runs_with_csv, key=lambda p: p.stat().st_mtime)
+    else:
+        latest = max(runs, key=lambda p: p.stat().st_mtime)
+
+    # compute simple run metadata: max delta across weight detail CSVs
+    try:
+        import csv
+
+        max_delta = 0.0
+        for csvf in latest.glob('weight_*_details.csv'):
+            with csvf.open('r', encoding='utf-8') as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    try:
+                        d = float(row.get('delta', '0'))
+                    except Exception:
+                        d = 0.0
+                    if d > max_delta:
+                        max_delta = d
+    except Exception:
+        max_delta = 0.0
+
+    meta = {'run_dir': str(latest), 'max_delta': float(max_delta)}
+    # backward compatibility: if called with the default signature return the run_dir string
+    if retries == 3 and backoff_factor == 0.5:
+        return str(latest)
+    return meta
 
 
 def run_exchange(personas: dict[str, str], rounds: int = 2):

--- a/scripts/dev/orchestrator.py
+++ b/scripts/dev/orchestrator.py
@@ -149,7 +149,7 @@ def ops_run_tuning(weights: list[float] | None = None, dry_run: bool = True) -> 
             print(f"ops_run_tuning: attempt {attempts} running sweep script (cmd={cmd})")
             subprocess.check_call(cmd, cwd=repo_root)
             break
-        except (subprocess.CalledProcessError, OSError) as exc:
+        except Exception as exc:
             print(f"ops_run_tuning: attempt {attempts} failed with: {exc}")
             if attempts >= max_retries:
                 print(f"ops_run_tuning: exceeded max retries ({max_retries}), aborting")

--- a/scripts/dev/run_plan.py
+++ b/scripts/dev/run_plan.py
@@ -8,12 +8,14 @@ def main() -> None:
     os.environ['PLAN'] = 'please run crib_weight_sweep; dry_run'
     os.environ['OPS_RUN'] = '1'
 
-    # ensure repo root (project root) is on sys.path
-    repo = Path(__file__).resolve().parents[2]
-    sys.path.insert(0, str(repo))
-
-    # import and run the plan check after adjusting sys.path
-    from scripts.dev.ask_triumverate import run_plan_check
+    # Prefer package import; fall back to inserting repo root on sys.path
+    try:
+        from kryptos.scripts.dev.ask_triumverate import run_plan_check
+    except Exception:
+        repo = Path(__file__).resolve().parents[2]
+        if str(repo) not in sys.path:
+            sys.path.insert(0, str(repo))
+        from scripts.dev.ask_triumverate import run_plan_check
 
     print('Running plan check (runner)')
     run_plan_check(os.environ['PLAN'])

--- a/scripts/dev/spy_extractor.py
+++ b/scripts/dev/spy_extractor.py
@@ -41,7 +41,13 @@ def find_latest_run() -> Path | None:
 
 
 def scan_run(run_dir: Path, cribs: set[str]) -> list[tuple[str, str, float]]:
-    results = []
+    """Scan per-weight detail CSVs and return tuples of (filename, matched_tokens, delta).
+
+    Prefer tokens that appear inside quotes in the sample. If quoted tokens are present
+    and match the crib list, prefer those. Dedupe matches per run by token.
+    """
+    results: list[tuple[str, str, float]] = []
+    seen_tokens: set[str] = set()
     for csvf in run_dir.glob('weight_*_details.csv'):
         with csvf.open('r', encoding='utf-8') as fh:
             reader = csv.DictReader(fh)
@@ -54,9 +60,19 @@ def scan_run(run_dir: Path, cribs: set[str]) -> list[tuple[str, str, float]]:
                 # only consider positive deltas
                 if delta <= 0:
                     continue
-                # find any crib tokens appearing in sample
-                tokens = re.findall(r"[A-Z]{3,}", sample.upper())
-                matches = [t for t in tokens if t in cribs]
+
+                text = sample.upper()
+                # find quoted uppercase tokens first
+                quoted = re.findall(r'["\']([A-Z]{3,})["\']', text)
+                if quoted:
+                    tokens_to_check = quoted
+                else:
+                    tokens_to_check = re.findall(r'[A-Z]{3,}', text)
+
+                matches = [t for t in tokens_to_check if t in cribs and t not in seen_tokens]
+                for t in matches:
+                    seen_tokens.add(t)
+
                 if matches:
                     results.append((csvf.name, ','.join(matches), delta))
     return results
@@ -78,11 +94,18 @@ def main():
     if not res:
         print('No conservative crib matches found in latest run')
         return 0
+
+    # compute a simple confidence score relative to the max delta in this run
+    max_delta = max((d for _, _, d in res), default=0.0)
+    notes_written = 0
     for fname, matches, delta in res:
-        note = f"SPY_MATCH {fname}: {matches} (delta={delta:.6f})"
+        conf = 0.0 if max_delta <= 0 else float(delta) / float(max_delta)
+        note = f"SPY_MATCH {fname}: {matches} (delta={delta:.6f}, conf={conf:.2f})"
         append_learned(note)
         print(note)
-    print(f'Appended {len(res)} learned entries to {LEARNED}')
+        notes_written += 1
+
+    print(f'Appended {notes_written} learned entries to {LEARNED}')
     return 0
 
 

--- a/scripts/lint/check_md.py
+++ b/scripts/lint/check_md.py
@@ -1,0 +1,76 @@
+"""Small markdown checker for common style issues.
+
+Rules:
+- No leading-space list markers (lines starting with ' - ' or ' * ')
+- No trailing whitespace
+- Max line length 120
+
+Run from repo root.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MD_PATHS = [ROOT / 'docs', ROOT / 'README.md']
+IGNORED_DIRS = [ROOT / 'docs' / 'sources']
+
+errs = 0
+
+
+def check_file(path: Path) -> int:
+    global errs
+    in_code = False
+    with path.open(encoding='utf-8') as fh:
+        for i, ln in enumerate(fh, start=1):
+            line = ln.rstrip('\n')
+            ls = line.lstrip()
+            # toggle code-fence state
+            if ls.startswith('```'):
+                in_code = not in_code
+                continue
+            if in_code:
+                continue
+            # skip obvious non-paragraph lines: URLs, tables
+            if 'http://' in line or 'https://' in line:
+                continue
+            if '|' in line and not line.strip().startswith('|-'):
+                continue
+            if line.endswith(' '):
+                print(f"{path}:{i}: trailing whitespace")
+                errs += 1
+            if len(line) > 120:
+                print(f"{path}:{i}: line too long ({len(line)})")
+                errs += 1
+            if line.startswith(' - ') or line.startswith(' * '):
+                print(f"{path}:{i}: leading-space list marker")
+                errs += 1
+    return 0
+
+
+def iter_md_files():
+    for p in MD_PATHS:
+        if p.is_file():
+            yield p
+        elif p.is_dir():
+            for f in p.rglob('*.md'):
+                # skip large source docs that intentionally contain long lines
+                if any(str(f).startswith(str(d)) for d in IGNORED_DIRS):
+                    continue
+                yield f
+
+
+def main():
+    for f in iter_md_files():
+        check_file(f)
+    if errs:
+        print(f"Found {errs} markdown issues")
+        sys.exit(2)
+    print("No markdown issues detected")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/lint/reflow_md.py
+++ b/scripts/lint/reflow_md.py
@@ -1,0 +1,119 @@
+"""Simple markdown reflow tool.
+
+Usage: python scripts/lint/reflow_md.py <file1.md> [file2.md ...]
+
+Rules:
+- Preserve code fences (``` blocks) and indented code blocks.
+- Preserve tables (lines containing '|') and lines containing URLs.
+- Reflow paragraphs and list-item text to a max width (default 100 chars).
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+MAX_WIDTH = 100
+
+
+def should_skip_line(line: str) -> bool:
+    s = line.lstrip()
+    # code fence
+    if s.startswith('```'):
+        return True
+    # indented code
+    if line.startswith('    ') or line.startswith('\t'):
+        return True
+    # tables
+    if '|' in line and not line.strip().startswith('|-'):
+        return True
+    # lines with URLs
+    if 'http://' in line or 'https://' in line:
+        return True
+    # headers
+    if s.startswith('#'):
+        return True
+    return False
+
+
+def reflow_file(path: Path) -> None:
+    txt = path.read_text(encoding='utf-8')
+    lines = txt.splitlines()
+    out_lines: list[str] = []
+    in_code = False
+    para_acc: list[str] = []
+
+    def flush_para():
+        nonlocal para_acc
+        if not para_acc:
+            return
+        para = ' '.join([p.strip() for p in para_acc])
+        wrapped = textwrap.fill(para, width=MAX_WIDTH)
+        out_lines.extend(wrapped.splitlines())
+        para_acc = []
+
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith('```'):
+            # toggle code fence
+            flush_para()
+            out_lines.append(line)
+            in_code = not in_code
+            continue
+        if in_code:
+            out_lines.append(line)
+            continue
+        if should_skip_line(line):
+            flush_para()
+            out_lines.append(line)
+            continue
+        # blank line ends paragraph
+        if line.strip() == '':
+            flush_para()
+            out_lines.append('')
+            continue
+        # list item: preserve bullet and reflow the remainder
+        if stripped.startswith(('- ', '* ', '+ ')):
+            flush_para()
+            marker = line[: line.find(stripped)] + stripped[:2]
+            rest = stripped[2:]
+            if rest.strip() == '':
+                out_lines.append(line)
+            else:
+                wrapped = textwrap.fill(rest.strip(), width=MAX_WIDTH - len(marker))
+                wrapped_lines = wrapped.splitlines()
+                out_lines.append(marker + wrapped_lines[0])
+                indent = ' ' * len(marker)
+                for wl in wrapped_lines[1:]:
+                    out_lines.append(indent + wl)
+            continue
+        # normal paragraph line: accumulate
+        para_acc.append(line)
+
+    flush_para()
+    new_txt = '\n'.join(out_lines) + '\n'
+    path.write_text(new_txt, encoding='utf-8')
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print('Usage: reflow_md.py <file-or-dir> [file-or-dir ...]')
+        return 2
+    for p in argv[1:]:
+        fp = Path(p)
+        if not fp.exists():
+            print(f'Skipping missing: {p}')
+            continue
+        if fp.is_dir():
+            for f in fp.rglob('*.md'):
+                print(f'Reflowing: {f}')
+                reflow_file(f)
+        else:
+            print(f'Reflowing: {fp}')
+            reflow_file(fp)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv))

--- a/scripts/lint/run_lint.ps1
+++ b/scripts/lint/run_lint.ps1
@@ -1,1 +1,61 @@
+<#
+Run the repository linters. This script attempts to run ruff, pylint, and a small
+markdown checker. It is tolerant if a tool isn't installed and prints install
+instructions.
+
+Usage:
+  pwsh ./scripts/lint/run_lint.ps1
+#>
+
+Write-Host "Starting lint run..."
+
+# Helper: run command if available
+function Invoke-IfExists($cmd, $cmdArgs) {
+    $exe = Get-Command $cmd -ErrorAction SilentlyContinue
+    if ($null -ne $exe) {
+        Write-Host "Running: $cmd $cmdArgs"
+        # split args into array so subcommands and params are passed separately
+        $argArray = @()
+        if ($null -ne $cmdArgs -and $cmdArgs -ne '') {
+            $argArray = $cmdArgs -split '\s+'
+        }
+        & $cmd @argArray
+        return $LASTEXITCODE
+    }
+    else {
+        Write-Host "Tool not found: $cmd (skipping)"
+        return 0
+    }
+}
+
+$errs = 0
+
+# 1) ruff
+ Invoke-IfExists ruff "check ."
+ $r = $LASTEXITCODE
+ if ($r -ne 0) { $errs += $r }
+
+# 2) pylint (examples & scripts)
+ Invoke-IfExists pylint "examples scripts --rcfile .pylintrc"
+ $p = $LASTEXITCODE
+ if ($p -ne 0) { $errs += $p }
+
+# 3) markdown checker (python)
+$py = Get-Command python -ErrorAction SilentlyContinue
+if ($null -ne $py) {
+    Write-Host "Running markdown checks"
+    python .\scripts\lint\check_md.py
+    if ($LASTEXITCODE -ne 0) { $errs += $LASTEXITCODE }
+} else {
+    Write-Host "Python not found; skipping markdown checks"
+}
+
+if ($errs -ne 0) {
+    Write-Host "Linting completed with errors: $errs" -ForegroundColor Red
+    exit 1
+}
+else {
+    Write-Host "Linting completed OK" -ForegroundColor Green
+    exit 0
+}
 pwsh -NoLogo -Command "python -m flake8 src tests"

--- a/scripts/run_lint.ps1
+++ b/scripts/run_lint.ps1
@@ -1,1 +1,0 @@
-pwsh -NoLogo -Command "python -m flake8 src tests"

--- a/scripts/run_tests_coverage.ps1
+++ b/scripts/run_tests_coverage.ps1
@@ -1,1 +1,0 @@
-pwsh -NoLogo -Command "& './scripts/lint/run_tests_coverage.ps1'"

--- a/scripts/tools/run_pipeline_sample.py
+++ b/scripts/tools/run_pipeline_sample.py
@@ -22,17 +22,17 @@ for p in (str(ROOT), str(SRC_DIR)):
     if p not in sys.path:
         sys.path.insert(0, p)
 
-# Try a few import fallbacks depending on how the workspace is invoked
-try:  # pragma: no cover - import resolution logic
-    from src.k4.executor import PipelineConfig, PipelineExecutor  # type: ignore
-    from src.k4.pipeline import make_hill_constraint_stage, make_masking_stage  # type: ignore
-except ImportError:  # pragma: no cover
+try:  # prefer installed package
+    from kryptos.src.k4.executor import PipelineConfig, PipelineExecutor  # type: ignore
+    from kryptos.src.k4.pipeline import make_hill_constraint_stage, make_masking_stage  # type: ignore
+except Exception:  # fallback to workspace src/ layout
     try:
+        from src.k4.executor import PipelineConfig, PipelineExecutor  # type: ignore
+        from src.k4.pipeline import make_hill_constraint_stage, make_masking_stage  # type: ignore
+    except Exception:
+        # finally, rely on the earlier sys.path insert to resolve `k4` top-level package
         from k4.executor import PipelineConfig, PipelineExecutor  # type: ignore
         from k4.pipeline import make_hill_constraint_stage, make_masking_stage  # type: ignore
-    except ImportError:  # pragma: no cover
-        from kryptos.src.k4.executor import PipelineConfig, PipelineExecutor  # type: ignore
-        from kryptos.src.k4.pipeline import make_hill_constraint_stage, make_masking_stage  # type: ignore
 
 # Short slice of K4 for quick run
 CIPHERTEXT = "OBKRUOXOGHULBSOLIFB"

--- a/scripts/tools/run_sweep_on_artifact_samples.py
+++ b/scripts/tools/run_sweep_on_artifact_samples.py
@@ -15,11 +15,16 @@ import sys
 import time
 from pathlib import Path
 
-scoring = importlib.import_module('k4.scoring')
-
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / 'src'
-sys.path.insert(0, str(SRC))
+
+# Prefer package import; fall back to adding src/ to sys.path
+try:
+    scoring = importlib.import_module('src.k4.scoring')
+except Exception:
+    if str(SRC) not in sys.path:
+        sys.path.insert(0, str(SRC))
+    scoring = importlib.import_module('k4.scoring')
 
 
 def load_cribs(path: Path) -> list[str]:

--- a/scripts/tuning/compare_crib_integration.py
+++ b/scripts/tuning/compare_crib_integration.py
@@ -12,10 +12,8 @@ import sys
 import time
 from pathlib import Path
 
-# ensure src/ is importable when running from the repo root
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
-sys.path.insert(0, str(SRC))
 
 
 def load_cribs_from_docs(path: Path) -> list[str]:
@@ -43,7 +41,12 @@ SAMPLES = [
 
 
 def run():
-    from k4 import scoring
+    try:
+        from src.k4 import scoring
+    except Exception:
+        if str(SRC) not in sys.path:
+            sys.path.insert(0, str(SRC))
+        from k4 import scoring
 
     docs_path = ROOT / "docs" / "sources" / "sanborn_crib_candidates.txt"
     cribs = load_cribs_from_docs(docs_path)

--- a/scripts/tuning/crib_weight_sweep.py
+++ b/scripts/tuning/crib_weight_sweep.py
@@ -12,8 +12,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
-if str(SRC) not in sys.path:
-    sys.path.insert(0, str(SRC))
 
 
 def load_cribs(path: Path) -> list[str]:
@@ -45,7 +43,16 @@ def run():
     parser.add_argument('--dry-run', action='store_true', help='Dry run flag (no external side-effects)')
     args = parser.parse_args()
 
-    from k4 import scoring
+    # Prefer installed package import, fall back to workspace src/ layout
+    try:
+        from kryptos.src.k4 import scoring
+    except Exception:
+        try:
+            from src.k4 import scoring
+        except Exception:
+            if str(SRC) not in sys.path:
+                sys.path.insert(0, str(SRC))
+            from k4 import scoring
 
     cribs_path = ROOT / "docs" / "sources" / "sanborn_crib_candidates.txt"
     cribs = load_cribs(cribs_path)

--- a/scripts/tuning/crib_weight_sweep.py
+++ b/scripts/tuning/crib_weight_sweep.py
@@ -10,10 +10,10 @@ import sys
 import time
 from pathlib import Path
 
-# Ensure src/ is importable when running from repo root
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
-sys.path.insert(0, str(SRC))
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
 
 
 def load_cribs(path: Path) -> list[str]:

--- a/scripts/tuning/spy_eval.py
+++ b/scripts/tuning/spy_eval.py
@@ -49,19 +49,10 @@ def select_best_threshold(labels_path: Path, runs_root: Path, thresholds: list[f
 
 
 def run_extractor_on_run(run_dir: Path, min_conf: float = 0.0) -> set[str]:
-    # run the spy_extractor main logic but import and call scan_run directly
-    repo = Path(__file__).resolve().parents[2]
-    spy_mod = None
+    # import the installed package's spy_extractor and call scan_run directly
     try:
-        import importlib.util
-
-        spec = importlib.util.spec_from_file_location(
-            'spy_eval_mod',
-            str(repo / 'scripts' / 'dev' / 'spy_extractor.py'),
-        )
-        spy_mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(spy_mod)  # type: ignore
-    except (ImportError, FileNotFoundError, AttributeError):
+        from kryptos.scripts.dev import spy_extractor as spy_mod
+    except Exception:
         return set()
 
     cribs = spy_mod.load_cribs(spy_mod.CRIBS)

--- a/scripts/tuning/spy_eval.py
+++ b/scripts/tuning/spy_eval.py
@@ -1,0 +1,119 @@
+"""SPY evaluation harness
+
+Scans tuning runs and computes precision/recall/F1 for SPY extractor matches
+against a labeled CSV of expected crib tokens per run.
+
+Labels CSV format: run_dir,token
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+def load_labels(path: Path) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    if not path.exists():
+        return out
+    with path.open('r', encoding='utf-8') as fh:
+        reader = csv.reader(fh)
+        for row in reader:
+            if not row:
+                continue
+            run, tok = row[0].strip(), row[1].strip().upper()
+            out.setdefault(run, set()).add(tok)
+    return out
+
+
+def select_best_threshold(labels_path: Path, runs_root: Path, thresholds: list[float] | None = None) -> float:
+    """Select the threshold preferring precision (more conservative extraction).
+
+    The selection now prefers the threshold with the highest precision. If
+    multiple thresholds share the same precision, pick the one with the
+    highest F1 as a tie-breaker. Returns 0.0 if no data is available.
+    """
+    res = evaluate(labels_path, runs_root, thresholds=thresholds)
+    if not res:
+        return 0.0
+    # pick threshold with max precision; tie-breaker picks the higher F1
+    best_th = 0.0
+    best_prec = -1.0
+    best_f1 = -1.0
+    for th, (prec_v, _rec_v, f1_v) in res.items():
+        if prec_v > best_prec or (prec_v == best_prec and f1_v > best_f1):
+            best_prec = prec_v
+            best_f1 = f1_v
+            best_th = th
+    return float(best_th)
+
+
+def run_extractor_on_run(run_dir: Path, min_conf: float = 0.0) -> set[str]:
+    # run the spy_extractor main logic but import and call scan_run directly
+    repo = Path(__file__).resolve().parents[2]
+    spy_mod = None
+    try:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            'spy_eval_mod',
+            str(repo / 'scripts' / 'dev' / 'spy_extractor.py'),
+        )
+        spy_mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(spy_mod)  # type: ignore
+    except (ImportError, FileNotFoundError, AttributeError):
+        return set()
+
+    cribs = spy_mod.load_cribs(spy_mod.CRIBS)
+    scan_res = spy_mod.scan_run(run_dir, cribs)
+    max_delta = max((d for _, _, d in scan_res), default=0.0)
+    tokens = set()
+    for _, matches, delta in scan_res:
+        conf = 0.0 if max_delta <= 0 else float(delta) / float(max_delta)
+        if conf >= min_conf:
+            for t in matches.split(','):
+                tokens.add(t)
+    return tokens
+
+
+def evaluate(
+    labels_path: Path,
+    runs_root: Path,
+    thresholds: list[float] | None = None,
+) -> dict[float, tuple[float, float, float]]:
+    labels = load_labels(labels_path)
+    if thresholds is None:
+        thresholds = [0.0, 0.25, 0.5, 0.75]
+    out: dict[float, tuple[float, float, float]] = {}
+    for threshold in thresholds:
+        tp = 0
+        fp = 0
+        fn = 0
+        for run_dir in runs_root.iterdir():
+            if not run_dir.is_dir() or not run_dir.name.startswith('run_'):
+                continue
+            run_name = run_dir.name
+            true = labels.get(run_name, set())
+            preds = run_extractor_on_run(run_dir, min_conf=threshold)
+            tp += len(preds & true)
+            fp += len(preds - true)
+            fn += len(true - preds)
+        prec_v = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        rec_v = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        f1_v = (2 * prec_v * rec_v / (prec_v + rec_v)) if (prec_v + rec_v) > 0 else 0.0
+        out[threshold] = (prec_v, rec_v, f1_v)
+    return out
+
+
+if __name__ == '__main__':
+    import argparse
+
+    p = argparse.ArgumentParser(description='Evaluate SPY extractor across thresholds')
+    p.add_argument('--labels', type=str, default='data/spy_eval_labels.csv', help='CSV of run_dir,token')
+    p.add_argument('--runs', type=str, default='artifacts/tuning_runs', help='Root tuning runs folder')
+    args = p.parse_args()
+    labels_path = Path(args.labels)
+    runs_root = Path(args.runs)
+    eval_res = evaluate(labels_path, runs_root)
+    for th, (prec_v, rec_v, f1_v) in eval_res.items():
+        print(f'th={th:.2f} prec={prec_v:.3f} rec={rec_v:.3f} f1={f1_v:.3f}')

--- a/scripts/tuning/tiny_tuning_sweep.py
+++ b/scripts/tuning/tiny_tuning_sweep.py
@@ -12,11 +12,8 @@ import sys
 import time
 from pathlib import Path
 
-# Ensure src/ is on sys.path so `from k4 import scoring` resolves when running
-# the script from the workspace root.
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
-sys.path.insert(0, str(SRC))
 
 ARTIFACTS = Path("artifacts") / "tuning_runs"
 ARTIFACTS.mkdir(parents=True, exist_ok=True)
@@ -37,8 +34,13 @@ PARAM_GRID = [
 
 
 def run():
-    # Import scoring here after ensuring src/ is on sys.path so linters don't flag E402
-    from k4 import scoring
+    # Prefer package import; fall back to adding src/ to sys.path for standalone runs
+    try:
+        from src.k4 import scoring
+    except Exception:
+        if str(SRC) not in sys.path:
+            sys.path.insert(0, str(SRC))
+        from k4 import scoring
 
     ts = time.strftime("%Y%m%dT%H%M%S")
     run_dir = ARTIFACTS / f"run_{ts}"

--- a/src/k4/executor.py
+++ b/src/k4/executor.py
@@ -124,7 +124,9 @@ class PipelineExecutor:
             return res
 
         with ThreadPoolExecutor(max_workers=variant_ct) as ex:
-            futures = [ex.submit(_variant_call, p_len, p_min) for p_len, p_min in zip(partial_lens, partial_mins)]
+            futures = []
+            for p_len, p_min in zip(partial_lens, partial_mins, strict=True):
+                futures.append(ex.submit(_variant_call, p_len, p_min))
             for fut in as_completed(futures):
                 try:
                     r = fut.result()

--- a/tests/test_create_pr.py
+++ b/tests/test_create_pr.py
@@ -1,0 +1,14 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def test_create_pr_requires_token():
+    mod_path = Path(__file__).resolve().parents[1] / 'scripts' / 'dev' / 'create_pr.py'
+    spec = importlib.util.spec_from_file_location('create_pr', str(mod_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+
+    with pytest.raises(ValueError):
+        mod.create_pr('owner', 'repo', head='feature/no-token', token=None)

--- a/tests/test_e2e_dryrun.py
+++ b/tests/test_e2e_dryrun.py
@@ -1,0 +1,46 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_e2e_autopilot_dryrun(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    orch_path = repo / 'scripts' / 'dev' / 'orchestrator.py'
+    spy_path = repo / 'scripts' / 'dev' / 'spy_extractor.py'
+
+    spec = importlib.util.spec_from_file_location('orch_e2e', str(orch_path))
+    orch = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(orch)  # type: ignore
+
+    # backup LEARNED.md if present
+    learned = repo / 'agents' / 'LEARNED.md'
+    backup = None
+    if learned.exists():
+        backup = tmp_path / 'LEARNED.bak'
+        backup.write_bytes(learned.read_bytes())
+
+    # run ops tuning dry-run
+    run_dir = orch.ops_run_tuning(weights=[0.1, 0.5, 1.0], dry_run=True)
+    assert run_dir, 'ops_run_tuning did not produce a run directory'
+    runp = Path(run_dir)
+    assert (runp / 'crib_weight_sweep.csv').exists()
+
+    # run spy_extractor main
+    spec2 = importlib.util.spec_from_file_location('spy_e2e', str(spy_path))
+    spy = importlib.util.module_from_spec(spec2)
+    spec2.loader.exec_module(spy)  # type: ignore
+
+    # run the extractor and ensure it completes
+    rv = spy.main()
+    assert rv == 0
+
+    # LEARNED.md should now exist and contain SPY_MATCH lines
+    assert learned.exists(), 'agents/LEARNED.md was not created'
+    text = learned.read_text(encoding='utf-8')
+    assert 'SPY_MATCH' in text, 'No SPY_MATCH entries written to LEARNED.md'
+
+    # restore backup
+    if backup and backup.exists():
+        learned.write_bytes(backup.read_bytes())
+    else:
+        # if no backup, clear the file to avoid side-effects
+        learned.write_text('', encoding='utf-8')

--- a/tests/test_k4_demo.py
+++ b/tests/test_k4_demo.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_run_k4_demo_smoke():
+    # import and run demo in-process
+    from scripts.demo.run_k4_demo import run_demo
+
+    out = run_demo(limit=5)
+    p = Path(out)
+    assert p.exists() and p.is_dir()
+    # expect a persist_attempt_logs output file (reports/...), at least one file present
+    files = list(p.rglob('*'))
+    assert files, 'Expected demo artifacts to be written'

--- a/tests/test_k4_scaffolding.py
+++ b/tests/test_k4_scaffolding.py
@@ -36,7 +36,9 @@ class TestK4Scaffold(unittest.TestCase):
         part = (12, 12, 12, 12, 12, 12, 12, 13)  # sums to 97
         segs = self.src.slice_by_partition(text, part)
         self.assertEqual(len(segs), len(part))
-        self.assertTrue(all(len(s) == expected for s, expected in zip(segs, part)))
+        # ensure each segment length matches the partition sizes
+        for s, expected in zip(segs, part, strict=True):
+            self.assertEqual(len(s), expected)
 
     def test_scoring_basic(self):
         """Test basic plaintext scoring functionality."""

--- a/tests/test_ops_run.py
+++ b/tests/test_ops_run.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+def test_ops_run_tuning_dry_run():
+    # import the orchestrator from scripts/dev by executing the file
+    here = Path(__file__).resolve().parent
+    repo_root = here.parent
+    orch_path = repo_root / 'scripts' / 'dev' / 'orchestrator.py'
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location('orch_test', str(orch_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+
+    # run with dry_run True and a tiny weight list
+    run_dir = mod.ops_run_tuning(weights=[0.1, 0.5, 1.0], dry_run=True)
+    assert run_dir, 'ops_run_tuning returned empty run path'
+    p = Path(run_dir)
+    assert p.exists() and p.is_dir(), f'Run dir does not exist: {run_dir}'
+    # expect the sweep csv file to be present
+    assert (p / 'crib_weight_sweep.csv').exists(), 'crib_weight_sweep.csv missing in run dir'

--- a/tests/test_ops_run_metadata.py
+++ b/tests/test_ops_run_metadata.py
@@ -1,0 +1,65 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_ops_run_tuning_returns_metadata(tmp_path, monkeypatch):
+    repo = Path(__file__).resolve().parents[1]
+    orch_path = repo / 'scripts' / 'dev' / 'orchestrator.py'
+    spec = importlib.util.spec_from_file_location('orch_meta', str(orch_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+
+    # prepare a fake artifacts/tuning_runs/run_x directory with detail CSV
+    # tr_root is unused, so it has been removed
+    # tr_root = Path('artifacts') / 'tuning_runs'
+    run_dir = tmp_path / 'artifacts' / 'tuning_runs' / 'run_test'
+    run_dir.mkdir(parents=True)
+    detail = run_dir / 'weight_0_1_details.csv'
+    with detail.open('w', encoding='utf-8') as fh:
+        fh.write('sample,baseline,with_cribs,delta\n')
+        fh.write("SAMPLE,0,1,0.5\n")
+        fh.write("SAMPLE,0,1,2.0\n")
+
+    # monkeypatch the repo path detection to treat tmp_path as the repo root
+    monkeypatch.setenv('PYTEST_ORCH_ROOT', str(tmp_path))
+
+    # monkeypatch subprocess.check_call to just create the run directory under repo
+    def fake_check_call(cmd, cwd=None):
+        # create the run dir in the expected artifacts location inside cwd
+        target = Path(cwd) / 'artifacts' / 'tuning_runs' / 'run_test'
+        target.mkdir(parents=True, exist_ok=True)
+        # copy our detail CSV into that location
+        (target / 'weight_0_1_details.csv').write_text(detail.read_text(), encoding='utf-8')
+        # also write a minimal crib_weight_sweep.csv to mimic real sweep script
+        try:
+            (target / 'crib_weight_sweep.csv').write_text('weight,metric\n0.1,1.0\n', encoding='utf-8')
+        except Exception:
+            pass
+        # ensure this run appears newest by setting its mtime to the future
+        import os
+        import time
+
+        future = time.time() + 10000
+        try:
+            os.utime(str(target / 'weight_0_1_details.csv'), (future, future))
+            os.utime(str(target), (future, future))
+        except Exception:
+            pass
+        return 0
+
+    monkeypatch.setattr(mod.subprocess, 'check_call', fake_check_call)
+
+    # call with non-default retries/backoff to get metadata dict
+    meta = mod.ops_run_tuning(weights=[0.1], dry_run=True, retries=2, backoff_factor=0.1)
+    assert isinstance(meta, dict)
+    assert 'run_dir' in meta and 'max_delta' in meta
+    assert meta['max_delta'] == 2.0
+    # cleanup the synthetic run created under the repo to avoid interfering with other tests
+    try:
+        import shutil
+
+        repo_run = Path('artifacts') / 'tuning_runs' / 'run_test'
+        if repo_run.exists():
+            shutil.rmtree(str(repo_run))
+    except Exception:
+        pass

--- a/tests/test_ops_run_retry.py
+++ b/tests/test_ops_run_retry.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_ops_run_tuning_retries(tmp_path, monkeypatch):
+    # load orchestrator module from scripts/dev
+    here = Path(__file__).resolve().parent
+    repo_root = here.parent
+    orch_path = repo_root / 'scripts' / 'dev' / 'orchestrator.py'
+    spec = importlib.util.spec_from_file_location('orch_retry', str(orch_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+
+    calls = {'count': 0}
+
+    def fake_check_call(cmd, cwd=None):
+        calls['count'] += 1
+        # fail the first two calls, succeed on the third
+        if calls['count'] < 3:
+            raise RuntimeError('simulated transient failure')
+        return 0
+
+    monkeypatch.setattr(mod.subprocess, 'check_call', fake_check_call)
+
+    # call ops_run_tuning which should retry and eventually return (or empty if it gives up)
+    # call ops_run_tuning which should retry and eventually return (or empty if it gives up)
+    _ = mod.ops_run_tuning(weights=[0.1], dry_run=True)
+    # since the fake_check_call doesn't actually create artifacts, function may return ''
+    # but it should have attempted 3 times
+    assert calls['count'] == 3, f"expected 3 attempts, got {calls['count']}"

--- a/tests/test_spy_eval.py
+++ b/tests/test_spy_eval.py
@@ -1,0 +1,32 @@
+import csv
+
+
+def test_spy_eval_smoke(tmp_path):
+    # create a fake run dir with a details csv
+    runs_root = tmp_path / 'artifacts' / 'tuning_runs'
+    run_dir = runs_root / 'run_test'
+    run_dir.mkdir(parents=True)
+    detail = run_dir / 'weight_0_1_details.csv'
+    with detail.open('w', encoding='utf-8') as fh:
+        writer = csv.writer(fh)
+        writer.writerow(['sample', 'baseline', 'with_cribs', 'delta'])
+        writer.writerow(["Found 'MAGNETIC' in sample", '0', '1', '1.0'])
+
+    # create labels file
+    labels = tmp_path / 'data' / 'spy_eval_labels.csv'
+    labels.parent.mkdir()
+    with labels.open('w', encoding='utf-8') as fh:
+        fh.write('run_test,MAGNETIC\n')
+
+    # import harness from package and run evaluate
+    import importlib
+
+    mod = importlib.import_module('kryptos.scripts.tuning.spy_eval')
+
+    res = mod.evaluate(labels, runs_root, thresholds=[0.0, 0.5])
+    assert 0.0 in res and 0.5 in res
+    # expect precision/recall values to be numeric
+    for _k, (p, r, f) in res.items():
+        assert isinstance(p, float)
+        assert isinstance(r, float)
+        assert isinstance(f, float)

--- a/tests/test_spy_extractor.py
+++ b/tests/test_spy_extractor.py
@@ -1,0 +1,33 @@
+import csv
+import importlib.util
+from pathlib import Path
+
+
+def test_spy_extractor_detects_quoted_crib(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    # Prepare a fake run directory structure
+    run_dir = tmp_path / 'run_test'
+    run_dir.mkdir()
+    detail = run_dir / 'weight_0_1_details.csv'
+    with detail.open('w', newline='', encoding='utf-8') as fh:
+        writer = csv.writer(fh)
+        writer.writerow(['sample', 'baseline', 'with_cribs', 'delta'])
+        # include a quoted crib token that should be in the real crib list (MAGNETIC)
+        writer.writerow(["It used the Earth's 'MAGNETIC' field", '0.0', '1.0', '1.0'])
+
+    # load the spy_extractor module
+    mod_path = repo / 'scripts' / 'dev' / 'spy_extractor.py'
+    spec = importlib.util.spec_from_file_location('spy_test', str(mod_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+
+    cribs = mod.load_cribs(mod.CRIBS)
+    assert 'MAGNETIC' in cribs, 'test expects MAGNETIC in the crib list'
+
+    res = mod.scan_run(run_dir, cribs)
+    assert res, 'spy_extractor should find matches in the fake run'
+    # expect the file and token to be reported
+    names = [r[0] for r in res]
+    assert 'weight_0_1_details.csv' in names
+    tokens = ','.join(r[1] for r in res)
+    assert 'MAGNETIC' in tokens

--- a/tests/test_spy_extractor_threshold.py
+++ b/tests/test_spy_extractor_threshold.py
@@ -1,0 +1,37 @@
+import csv
+import importlib.util
+from pathlib import Path
+
+
+def test_spy_extractor_min_conf(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    run_dir = tmp_path / 'run_test'
+    run_dir.mkdir()
+    detail = run_dir / 'weight_0_1_details.csv'
+    with detail.open('w', newline='', encoding='utf-8') as fh:
+        writer = csv.writer(fh)
+        writer.writerow(['sample', 'baseline', 'with_cribs', 'delta'])
+        # two rows with different deltas to create different confidences
+        writer.writerow(["The 'MAGNETIC' anomaly was noted", '0.0', '1.0', '1.0'])
+        writer.writerow(["Saw 'MAGNETIC' again", '0.0', '1.0', '0.1'])
+
+    # load module
+    mod_path = repo / 'scripts' / 'dev' / 'spy_extractor.py'
+    spec = importlib.util.spec_from_file_location('spy_test_conf', str(mod_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+
+    cribs = mod.load_cribs(mod.CRIBS)
+    assert 'MAGNETIC' in cribs
+
+    # scan_run should return both matches
+    res = mod.scan_run(run_dir, cribs)
+    assert res and len(res) >= 1
+
+    # compute filtering: call main with min_conf=0.9 to only keep the top match
+    # Use main directly; it expects to find runs in artifacts, so call the logic locally
+    max_delta = max((d for _, _, d in res), default=0.0)
+    assert max_delta > 0
+    # compute confidences
+    confs = [d / max_delta for _, _, d in res]
+    assert any(c >= 0.9 for c in confs)


### PR DESCRIPTION
# PR: chore(autopilot): add autopilot triune tooling (OPS / SPY / Orchestrator)

Short description

This branch implements an offline autopilot workflow ("triumverate") that wires together three components:

- OPS: tuning harnesses and deterministic sweeps to explore parameter spaces (e.g., crib weight sweeps).
- SPY: a conservative crib/token extractor plus an evaluation harness to choose conservative thresholds.
- Orchestrator: a small driver that runs OPS and then SPY, records run metadata, and appends learned hints to `agents/LEARNED.md`.

Other changes:

- Documentation: added `docs/10KFT.md` (10k-ft index), updated `docs/PLAN.md`, `ROADMAP.md`, and added flow/design notes.
- Linting: added `scripts/lint` utilities and integrated markdown reflow/check hooks into pre-commit.
- Packaging: corrected `pyproject.toml` to use setuptools package discovery (`[tool.setuptools.packages.find] where = ["src"]`) so editable installs work.
- Tests: updated/added tests; full test suite currently passes locally (140 passed, 0 failed).

Checklist for reviewer

- [ ] Read `docs/10KFT.md` and `docs/AUTOPILOT.md` for high-level flow.
- [ ] Confirm `pyproject.toml` change is acceptable (we now use `where = ["src"]`).
- [ ] Spot-check `scripts/dev/ask_triumverate.py` to ensure it meets expected orchestration semantics.
- [ ] Run `./scripts/lint/run_lint.ps1` and `pytest -q` locally to confirm no local environment regressions.

Testing steps (recommended)


1. Install editable package locally:

```powershell
Set-Location 'c:\Users\ajhar\code\kryptos'
python -m pip install -e .
```

2. Run the lint runner:

```powershell
./scripts/lint/run_lint.ps1
```

3. Run tests:

```powershell
pytest -q
```

4. Try a dry-run of the autopilot driver:

```powershell
python scripts/dev/ask_triumverate.py --dry-run
```

Notes for maintainers

- The pre-commit config now includes local markdown reflow/check hooks. Pre-commit will create a venv for these hooks during install.
- The SPY extractor favors precision-first thresholds; see `kryptos/scripts/tuning/spy_eval.py` for the selection logic.
- If CI shows new packaging or setuptools warnings regarding `project.license`, we may want to adopt SPDX license expression strings to silence deprecation warnings.

If you want I can open a PR draft with this description and include a short diff summary. Let me know and I'll create the PR body and push it to a branch ready for review.
