### PR TITLE
DevOps: Docker reliability and artifacts path fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.pytest_cache
+.ruff_cache
+.venv
+venv
+__pycache__
+artifacts
+htmlcov
+reports
+.pytest_cache
+*.pyc
+*.pyo
+*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@ __pycache__
 artifacts
 htmlcov
 reports
-.pytest_cache
 *.pyc
 *.pyo
 *.log

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,24 @@
+name: Docker Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  docker-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build image
+        run: docker build -t kryptos-docker-smoke .
+
+      - name: Verify CLI starts in container
+        run: docker run --rm kryptos-docker-smoke kryptos sections

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -20,5 +20,11 @@ jobs:
       - name: Build image
         run: docker build -t kryptos-docker-smoke .
 
-      - name: Verify CLI starts in container
-        run: docker run --rm kryptos-docker-smoke kryptos sections
+      - name: Verify CLI and artifact write paths in container
+        run: >
+          docker run --rm kryptos-docker-smoke
+          /bin/sh -lc
+          'set -e;
+          kryptos sections;
+          kryptos k4-attempts --label docker-smoke;
+          test -n "$(find artifacts/reports -maxdepth 2 -type f -name "attempts_*.json" -print -quit)"'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ Last Updated: 2026-03-27
 
 ## 2026 Q2 (In Progress)
 
-- [ ] Fix the container runtime write-permission path.
+- [x] Fix the container runtime write-permission path.
 - [ ] Complete Phase 6.2 composite validation.
 - [ ] Improve targeted coverage in low-coverage modules and raise the CI test coverage gate for these modules accordingly.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -8,13 +8,14 @@ Last Updated: 2026-03-27
 - [x] Add extensive test coverage and fast/slow execution partitioning.
 - [x] Add provenance logging and candidate artifact generation.
 - [x] Add layered CI validation.
+- [x] Fix the Docker runtime permission failure for artifact and log output.
+  - Completed: 2026-03-27
+  - Evidence: `docker run --rm kryptos-devops-check kryptos k4-attempts --label docker-smoke` now writes under the application working tree instead of `site-packages`.
+- [x] Add Docker smoke CI workflow.
+  - Completed: 2026-03-27
+  - Evidence: `.github/workflows/docker-smoke.yml` now builds the image and validates CLI startup.
 
 ## In Progress
-
-- [ ] Fix the Docker runtime permission failure for artifact and log output.
-  - Priority: P0
-  - Problem: the container still hits a `PermissionError` on the current artifact path.
-  - Acceptance Criteria: the container starts and writes to a writable application-owned location.
 
 - [ ] Complete Phase 6.2 composite-chain validation.
   - Priority: P1

--- a/src/kryptos/paths.py
+++ b/src/kryptos/paths.py
@@ -28,6 +28,15 @@ from pathlib import Path
 ENV_ROOT = "KRYPTOS_REPO_ROOT"
 
 
+def _find_repo_root(start: Path) -> Path | None:
+    current = start.resolve()
+    candidates = (current,) + tuple(current.parents)
+    for candidate in candidates:
+        if (candidate / "pyproject.toml").exists():
+            return candidate
+    return None
+
+
 @lru_cache(maxsize=1)
 def get_repo_root() -> Path:
     override = os.environ.get(ENV_ROOT)
@@ -35,10 +44,16 @@ def get_repo_root() -> Path:
         p = Path(override).resolve()
         if p.exists():
             return p
+
+    cwd_root = _find_repo_root(Path.cwd())
+    if cwd_root is not None:
+        return cwd_root
+
+    module_root = _find_repo_root(Path(__file__))
+    if module_root is not None:
+        return module_root
+
     here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "pyproject.toml").exists():
-            return parent
     return here.parents[1]
 
 

--- a/src/kryptos/paths.py
+++ b/src/kryptos/paths.py
@@ -28,12 +28,18 @@ from pathlib import Path
 ENV_ROOT = "KRYPTOS_REPO_ROOT"
 
 
-def _find_repo_root(start: Path) -> Path | None:
+def _is_kryptos_root(candidate: Path) -> bool:
+    """Return True only if *candidate* is the Kryptos repo root (contains src/kryptos/)."""
+    return (candidate / "src" / "kryptos").is_dir()
+
+
+def _find_repo_root(start: Path, kryptos_only: bool = False) -> Path | None:
     current = start.resolve()
     candidates = (current,) + tuple(current.parents)
     for candidate in candidates:
         if (candidate / "pyproject.toml").exists():
-            return candidate
+            if not kryptos_only or _is_kryptos_root(candidate):
+                return candidate
     return None
 
 
@@ -45,7 +51,9 @@ def get_repo_root() -> Path:
         if p.exists():
             return p
 
-    cwd_root = _find_repo_root(Path.cwd())
+    # Require the CWD-discovered root to be the Kryptos repo specifically, so
+    # that an unrelated project's pyproject.toml is never mistaken for ours.
+    cwd_root = _find_repo_root(Path.cwd(), kryptos_only=True)
     if cwd_root is not None:
         return cwd_root
 

--- a/tests/test_paths_helpers.py
+++ b/tests/test_paths_helpers.py
@@ -36,7 +36,9 @@ def test_provenance_hash_stable():
 def test_cwd_repo_root_preferred_for_installed_package(tmp_path, monkeypatch):
     repo_root = tmp_path / 'repo'
     repo_root.mkdir()
-    (repo_root / 'pyproject.toml').write_text('[project]\nname = "kryptos-test"\nversion = "0.0.0"\n', encoding='utf-8')
+    (repo_root / 'pyproject.toml').write_text('[project]\nname = "kryptos"\nversion = "0.0.0"\n', encoding='utf-8')
+    # Create the Kryptos-specific marker so _find_repo_root(kryptos_only=True) matches.
+    (repo_root / 'src' / 'kryptos').mkdir(parents=True)
 
     fake_site_packages = tmp_path / 'site-packages' / 'kryptos'
     fake_site_packages.mkdir(parents=True)

--- a/tests/test_paths_helpers.py
+++ b/tests/test_paths_helpers.py
@@ -33,6 +33,25 @@ def test_provenance_hash_stable():
     assert h3 != h1
 
 
+def test_cwd_repo_root_preferred_for_installed_package(tmp_path, monkeypatch):
+    repo_root = tmp_path / 'repo'
+    repo_root.mkdir()
+    (repo_root / 'pyproject.toml').write_text('[project]\nname = "kryptos-test"\nversion = "0.0.0"\n', encoding='utf-8')
+
+    fake_site_packages = tmp_path / 'site-packages' / 'kryptos'
+    fake_site_packages.mkdir(parents=True)
+    fake_module = fake_site_packages / 'paths.py'
+    fake_module.write_text('# placeholder', encoding='utf-8')
+
+    paths.get_repo_root.cache_clear()  # type: ignore[attr-defined]
+    monkeypatch.delenv(paths.ENV_ROOT, raising=False)
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setattr(paths, '__file__', str(fake_module))
+
+    assert paths.get_repo_root() == repo_root
+    assert paths.get_artifacts_root() == repo_root / 'artifacts'
+
+
 def test_containment_and_no_root_level_artifacts(tmp_path):
     # Ensure helper-created artifacts live directly under repo root
     repo_root = paths.get_repo_root()


### PR DESCRIPTION
## Summary

Improve Docker/runtime reliability by ensuring Kryptos always resolves its repo root to the correct working tree. The CWD-based root discovery is now tightened to only match the Kryptos repo specifically, preventing artifact and log writes from being misdirected to unrelated Python projects. Also adds lightweight Docker smoke validation and aligns project docs/roadmap.

## Changes

- Update `get_repo_root()` to prefer a CWD-discovered repo root before falling back to the module location.
- Add `_is_kryptos_root()` helper that validates the candidate directory contains `src/kryptos/`, ensuring the CWD-based search only matches the Kryptos repo and not any unrelated project with a `pyproject.toml`.
- Extend `_find_repo_root()` with a `kryptos_only` parameter; `get_repo_root()` passes `kryptos_only=True` for the CWD check.
- Update regression test `test_cwd_repo_root_preferred_for_installed_package` to create the `src/kryptos/` marker alongside the fake `pyproject.toml`, correctly simulating a Kryptos repo on the CWD path.
- Add Docker smoke GitHub Actions workflow that validates CLI and artifact write paths inside the container.
- Introduce `.dockerignore` (duplicate `.pytest_cache` entry removed).
- Align `TASKS.md` and `ROADMAP.md` to match validated state.

## Testing

- `pytest tests/test_paths_helpers.py -v` — all 5 tests pass, including the updated CWD-preference regression test.
- Verified manually that invoking Kryptos from an unrelated Python project directory no longer selects that project's `pyproject.toml` as the repo root.
- Docker smoke workflow exercises `kryptos sections` and `kryptos k4-attempts --label docker-smoke`, then asserts the expected `artifacts/reports/.../attempts_*.json` file exists.

## Screenshots (optional)

N/A

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if needed)
- [ ] Linked to related issues / tasks
- [x] Follows project conventions and style guidelines
- [x] Passes all automated checks (linting, tests, etc.)