### PR TITLE
Embed turbovec RAG behind a new FastAPI app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ MANIFEST
 *.tmp
 # Ignore generated data files if any
 /data/*.generated
+# turbovec RAG index, generated from gitignored artifacts/
+/data/turbovec/
 reports/
 artifacts/
 /agents/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
+        args: ["--line-length=120"]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+- `kryptos serve` command and minimal FastAPI app (`src/kryptos/api/`) exposing `/health`, `/api/rag/status`,
+  `POST /api/rag/reindex`, and `GET /api/rag/search` endpoints
+- turbovec-backed `ArtifactIndex` (`src/kryptos/rag/`) for semantic search over `artifacts/`, using
+  `sentence-transformers` embeddings and a 4-bit quantized `turbovec.IdMapIndex` persisted under `data/turbovec/`
+
 ## [Phase 6.3] - 2026-05-25
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,7 +4,7 @@
 > Cryptographic research toolkit for solving the K4 cipher puzzle
 
 ---
-**Last Updated:** 2026-06-01
+**Last Updated:** 2026-06-10
 ---
 
 
@@ -99,6 +99,16 @@
 - **`k4_research_findings`**: Confirmed facts and ruled-out hypotheses (19 entries, queryable by kind/confidence)
 - **`k4_keystream`**: Per-position crib/cipher/plain/shift data for all four confirmed cribs (24 rows)
 - **`source_chunks`**: Smithsonian 2009 oral history transcript chunked for semantic search (51 chunks)
+
+---
+
+## 🔍 RAG & Semantic Search (turbovec)
+
+- **`kryptos serve`**: Minimal FastAPI app exposing semantic search over `artifacts/` (decisions, hypotheses, logs, reports)
+- **turbovec-backed index**: Compressed vector index (`IdMapIndex`, 4-bit quantization) stored under `data/turbovec/`
+- **`sentence-transformers` embeddings**: `all-MiniLM-L6-v2` (384-dim, CPU-friendly) for chunk and query encoding
+- **Endpoints**: `GET /health`, `GET /api/rag/status`, `POST /api/rag/reindex`, `GET /api/rag/search?q=...&k=...`
+- **On-demand indexing**: Index is built via `/api/rag/reindex`, not automatically at startup — keeps the API lightweight until search is needed
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,44 @@ kryptos spy-extract --runs artifacts/tuning_runs --min-conf 0.25 > spy_tokens.js
 You now have: decrypt.json, sweep.json, holdout.json, spy_eval.json, spy_tokens.json summarizing the pipeline, tuning,
 and extraction outputs.
 
+## RAG API (turbovec)
+
+A lightweight FastAPI app provides semantic search over `artifacts/` (decisions, hypotheses, logs, reports), backed by
+a [turbovec](https://pypi.org/project/turbovec/) compressed vector index and `sentence-transformers` embeddings.
+
+Start the server:
+
+```bash
+kryptos serve --port 8000
+```
+
+Build (or rebuild) the index from the current `artifacts/` contents — required before searching, and after any
+`artifacts/` changes:
+
+```bash
+curl -X POST localhost:8000/api/rag/reindex
+```
+
+Check index status:
+
+```bash
+curl localhost:8000/api/rag/status
+```
+
+Semantic search:
+
+```bash
+curl "localhost:8000/api/rag/search?q=Hill+cipher+key+matrix&k=5"
+```
+
+Health check:
+
+```bash
+curl localhost:8000/health
+```
+
+The index is stored under `data/turbovec/` (gitignored, derived from `artifacts/`).
+
 ## Recent Changes
 
 - **2025-10-24**: Fixed CI failures by correcting `.gitignore` pattern - added agents source code (SPY, OPS, Q agents)
@@ -338,7 +376,7 @@ Run the fast test suite with coverage in a lightweight Docker container:
 
 ```bash
 docker run --rm -v "${PWD}:/app" -w /app python:3.13-slim sh -lc \
-  "pip install --no-cache-dir pytest pytest-cov numpy matplotlib requests beautifulsoup4 spacy nltk pyyaml && \
+  "pip install --no-cache-dir pytest pytest-cov numpy matplotlib requests beautifulsoup4 spacy nltk pyyaml fastapi httpx && \
    python -m spacy download en_core_web_sm && \
    pip install --no-cache-dir -e . --no-deps && \
    pytest tests/ -m 'not slow' --cov=src --cov-report=term"

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-06-09
+Last Updated: 2026-06-10
 
 
 ## Todo
@@ -31,6 +31,16 @@ Last Updated: 2026-06-09
 ## In Progress
 
 ## Done
+
+### RAG API (turbovec) — semantic search over `artifacts/`
+
+- [x] **`kryptos serve`** — minimal FastAPI app (`src/kryptos/api/`) with `/health`, `/api/rag/status`,
+  `POST /api/rag/reindex`, `GET /api/rag/search` endpoints
+- [x] **turbovec-backed `ArtifactIndex`** — `src/kryptos/rag/` chunks `artifacts/` (`.json`/`.md`), embeds with
+  `sentence-transformers` (`all-MiniLM-L6-v2`), indexes with `turbovec.IdMapIndex` (4-bit quantization), persisted
+  under `data/turbovec/`
+- This is the "Now" item from agent-board's `docs/AI_STACK_STRATEGY.md`, scoped separately from the Q1 2027 Phase 2
+  Data & API dashboard work above
 
 ### K4 Attack — Untested Vectors (PR #83, merged)
 

--- a/config/requirements-dev.txt
+++ b/config/requirements-dev.txt
@@ -5,3 +5,4 @@ flake8
 pytest
 pytest-cov
 pre-commit
+httpx  # FastAPI TestClient

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -8,5 +8,8 @@ pyyaml>=6.0.3
 openai>=2.41.0  # Optional: for OpenAI LLM integration
 transformers>=5.10.2  # Optional: for LINGUIST neural validation
 anthropic>=0.107.1  # Optional: for Anthropic LLM integration
-torch>=2.12.0  # Optional: for LINGUIST neural models
-sentence-transformers>=5.5.1  # Optional: for semantic embeddings
+torch>=2.12.0  # Optional: for LINGUIST neural models; also backs kryptos.rag embeddings
+sentence-transformers>=5.5.1  # Embeddings for kryptos.rag turbovec index (also used for LINGUIST)
+turbovec  # Compressed vector index for kryptos.rag (RAG over artifacts/)
+fastapi>=0.115  # `kryptos serve` API
+uvicorn[standard]>=0.34  # ASGI server for `kryptos serve`

--- a/src/kryptos/api/__init__.py
+++ b/src/kryptos/api/__init__.py
@@ -1,0 +1,8 @@
+"""Minimal FastAPI app exposing turbovec RAG search over `artifacts/`.
+
+Run with: `kryptos serve` (see `kryptos.cli.main.cmd_serve`).
+"""
+
+from kryptos.api.app import create_app
+
+__all__ = ["create_app"]

--- a/src/kryptos/api/app.py
+++ b/src/kryptos/api/app.py
@@ -1,0 +1,43 @@
+"""FastAPI app: health check + turbovec RAG search over `artifacts/`."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import FastAPI, HTTPException, Query
+
+from kryptos.rag.index import ArtifactIndex
+
+
+def create_app(index: ArtifactIndex | None = None) -> FastAPI:
+    index = index if index is not None else ArtifactIndex()
+    index.load()
+
+    app = FastAPI(title="Kryptos API", version="0.1.0")
+
+    @app.get("/health")
+    def health() -> dict:
+        return {"status": "ok"}
+
+    @app.get("/api/rag/status")
+    def rag_status() -> dict:
+        return index.status()
+
+    @app.post("/api/rag/reindex")
+    def rag_reindex() -> dict:
+        return index.build()
+
+    @app.get("/api/rag/search")
+    def rag_search(q: str = Query(..., min_length=1), k: int = Query(10, ge=1, le=50)) -> dict:
+        if not index.is_loaded:
+            raise HTTPException(
+                status_code=409,
+                detail="Index not built yet. POST /api/rag/reindex first.",
+            )
+        results = index.search(q, k=k)
+        return {"query": q, "results": [asdict(r) for r in results]}
+
+    return app
+
+
+app = create_app()

--- a/src/kryptos/cli/main.py
+++ b/src/kryptos/cli/main.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import argparse
@@ -7,21 +6,12 @@ import logging
 from pathlib import Path
 
 from kryptos import autopilot as autopilot_mod
-from kryptos.examples import (
-    purge_demo_artifacts,
-    run_composite_demo,
-    run_sections_demo,
-    run_tiny_weight_sweep,
-)
+from kryptos.examples import purge_demo_artifacts, run_composite_demo, run_sections_demo, run_tiny_weight_sweep
 from kryptos.k4 import decrypt_best
 from kryptos.k4 import scoring as k4_scoring
 from kryptos.k4.attempt_logging import persist_attempt_logs
 from kryptos.k4.report import write_condensed_report, write_top_candidates_markdown
-from kryptos.k4.tuning import (
-    pick_best_weight_from_rows,
-    run_crib_weight_sweep,
-    tiny_param_sweep,
-)
+from kryptos.k4.tuning import pick_best_weight_from_rows, run_crib_weight_sweep, tiny_param_sweep
 from kryptos.k4.tuning.artifacts import end_to_end_process
 from kryptos.k4.tuning.crib_sweep import WeightSweepRow
 from kryptos.log_setup import setup_logging
@@ -33,35 +23,36 @@ from kryptos.tuning import spy_eval
 def _print_sections(logger: logging.Logger, emit_log: bool = True, emit_print: bool = True) -> None:
     for name in SECTIONS:
         if emit_log:
-            logger.info('%s', name)
+            logger.info("%s", name)
         if emit_print:
             print(name)
 
 
 def cmd_sections(args: argparse.Namespace) -> int:
-    logger = logging.getLogger('kryptos.cli')
-    if not any(getattr(h, '_kryptos_handler', False) for h in logger.handlers):
-        logger = setup_logging(logger_name='kryptos.cli')
-    quiet = getattr(args, 'quiet', False)
+    logger = logging.getLogger("kryptos.cli")
+    if not any(getattr(h, "_kryptos_handler", False) for h in logger.handlers):
+        logger = setup_logging(logger_name="kryptos.cli")
+    quiet = getattr(args, "quiet", False)
     _print_sections(logger, emit_log=not quiet, emit_print=not quiet)
     return 0
 
 
-def _load_ciphertext(cipher_path: Path | None, section: str = 'K4') -> str:
+def _load_ciphertext(cipher_path: Path | None, section: str = "K4") -> str:
     if cipher_path is not None:
-        with open(cipher_path, encoding='utf-8') as fh:
+        with open(cipher_path, encoding="utf-8") as fh:
             return fh.read().strip()
     from kryptos.paths import get_repo_root
-    config_path = get_repo_root() / 'config' / 'config.json'
-    with open(config_path, encoding='utf-8') as fh:
-        return json.load(fh)['ciphertexts'][section]
+
+    config_path = get_repo_root() / "config" / "config.json"
+    with open(config_path, encoding="utf-8") as fh:
+        return json.load(fh)["ciphertexts"][section]
 
 
 def cmd_k4_decrypt(args: argparse.Namespace) -> int:
-    logger = setup_logging(logger_name='kryptos.cli')
+    logger = setup_logging(logger_name="kryptos.cli")
     ciphertext = _load_ciphertext(args.cipher)
     # Enable alphabet auto-selection by default unless explicitly disabled
-    try_all_alphabets = getattr(args, 'try_all_alphabets', True)
+    try_all_alphabets = getattr(args, "try_all_alphabets", True)
     res = decrypt_best(
         ciphertext,
         limit=args.limit,
@@ -69,10 +60,10 @@ def cmd_k4_decrypt(args: argparse.Namespace) -> int:
         report=args.report,
         try_all_alphabets=try_all_alphabets,
     )
-    logger.info('k4-decrypt score=%.3f lineage=%s', res.score, res.lineage)
+    logger.info("k4-decrypt score=%.3f lineage=%s", res.score, res.lineage)
     print(
         json.dumps(
-            {'plaintext': res.plaintext, 'score': res.score, 'lineage': res.lineage, 'artifacts': res.artifacts},
+            {"plaintext": res.plaintext, "score": res.score, "lineage": res.lineage, "artifacts": res.artifacts},
             indent=2,
         ),
     )
@@ -80,70 +71,71 @@ def cmd_k4_decrypt(args: argparse.Namespace) -> int:
 
 
 def cmd_k4_attempts(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     path = persist_attempt_logs(label=args.label.upper())
     print(path)
     return 0
 
 
-
 def cmd_sections_decrypt(args: argparse.Namespace) -> int:
     from kryptos.sections import SECTIONS
-    logger = setup_logging(logger_name='kryptos.cli')
+
+    logger = setup_logging(logger_name="kryptos.cli")
     section = args.section.upper()
     if section not in SECTIONS:
-        print(json.dumps({'error': 'invalid_section', 'section': section}))
+        print(json.dumps({"error": "invalid_section", "section": section}))
         return 2
     ciphertext = _load_ciphertext(args.cipher, section)
     decrypt_fn = SECTIONS[section]
     try:
-        explain = getattr(args, 'explain', False)
-        out = {'section': section}
-        if section in ('K1', 'K2'):
+        explain = getattr(args, "explain", False)
+        out = {"section": section}
+        if section in ("K1", "K2"):
             if not args.key:
-                print(json.dumps({'error': 'missing_key', 'section': section}))
+                print(json.dumps({"error": "missing_key", "section": section}))
                 return 2
             plaintext = decrypt_fn(ciphertext, args.key)
-            out['plaintext'] = plaintext
+            out["plaintext"] = plaintext
             if explain:
                 from kryptos.ciphers import KEYED_ALPHABET
-                out['explain'] = {
-                    'keyed_alphabet': KEYED_ALPHABET,
-                    'key': args.key,
-                    'note': 'K1/K2 use keyed Vigenère with this alphabet and provided key.'
+
+                out["explain"] = {
+                    "keyed_alphabet": KEYED_ALPHABET,
+                    "key": args.key,
+                    "note": "K1/K2 use keyed Vigenère with this alphabet and provided key.",
                 }
-        elif section == 'K3':
+        elif section == "K3":
             plaintext = decrypt_fn(ciphertext)
-            out['plaintext'] = plaintext
+            out["plaintext"] = plaintext
             if explain:
-                out['explain'] = {
-                    'matrix_1': {'cols': 24, 'rows': 14},
-                    'matrix_2': {'cols': 8, 'rows': 42},
-                    'note': 'K3 uses double rotational transposition with these matrix dimensions.'
+                out["explain"] = {
+                    "matrix_1": {"cols": 24, "rows": 14},
+                    "matrix_2": {"cols": 8, "rows": 42},
+                    "note": "K3 uses double rotational transposition with these matrix dimensions.",
                 }
-        elif section == 'K4':
+        elif section == "K4":
             res = decrypt_fn(ciphertext)
-            if hasattr(res, 'plaintext'):
-                out['plaintext'] = res.plaintext
+            if hasattr(res, "plaintext"):
+                out["plaintext"] = res.plaintext
                 if explain:
-                    meta = getattr(res, 'metadata', None)
-                    out['explain'] = meta if meta else {'note': 'No explainability metadata available for K4.'}
+                    meta = getattr(res, "metadata", None)
+                    out["explain"] = meta if meta else {"note": "No explainability metadata available for K4."}
             else:
-                out['plaintext'] = res
+                out["plaintext"] = res
                 if explain:
-                    out['explain'] = {'note': 'No explainability metadata available for K4.'}
+                    out["explain"] = {"note": "No explainability metadata available for K4."}
         else:
-            print(json.dumps({'error': 'unsupported_section', 'section': section}))
+            print(json.dumps({"error": "unsupported_section", "section": section}))
             return 2
-        if getattr(args, 'json', False):
+        if getattr(args, "json", False):
             print(json.dumps(out))
         else:
             print(json.dumps(out, indent=2))
         return 0
     except Exception as exc:
-        logger.error('sections-decrypt failed: %s', exc)
-        out = {'error': 'decrypt_failed', 'section': section, 'detail': str(exc)}
-        if getattr(args, 'json', False):
+        logger.error("sections-decrypt failed: %s", exc)
+        out = {"error": "decrypt_failed", "section": section, "detail": str(exc)}
+        if getattr(args, "json", False):
             print(json.dumps(out))
         else:
             print(json.dumps(out, indent=2))
@@ -151,253 +143,297 @@ def cmd_sections_decrypt(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Kryptos CLI')
-    parser.add_argument('--quiet', action='store_true', help='Suppress non-essential output (for CI/scripts)')
-    parser.add_argument('--log-level', type=str, default='INFO', help='Set log level (DEBUG, INFO, WARNING, ERROR)')
-    sub = parser.add_subparsers(dest='command', required=True)
+    parser = argparse.ArgumentParser(description="Kryptos CLI")
+    parser.add_argument("--quiet", action="store_true", help="Suppress non-essential output (for CI/scripts)")
+    parser.add_argument("--log-level", type=str, default="INFO", help="Set log level (DEBUG, INFO, WARNING, ERROR)")
+    sub = parser.add_subparsers(dest="command", required=True)
 
     # Other subcommands...
-    sp_sections = sub.add_parser('sections', help='List available sections')
+    sp_sections = sub.add_parser("sections", help="List available sections")
     sp_sections.set_defaults(func=cmd_sections)
 
-    sp_k4_decrypt = sub.add_parser('k4-decrypt', help='Decrypt K4 ciphertext')
-    sp_k4_decrypt.add_argument('--cipher', type=Path, default=None, help='Path to ciphertext file; omit to use K4 from config/config.json')
-    sp_k4_decrypt.add_argument('--limit', type=int, default=100, help='Candidate limit')
-    sp_k4_decrypt.add_argument('--adaptive', action='store_true', help='Enable adaptive mode')
-    sp_k4_decrypt.add_argument('--report', action='store_true', help='Emit report')
-    sp_k4_decrypt.add_argument('--no-auto-alphabet', dest='try_all_alphabets', action='store_false', help='Disable alphabet auto-selection (default: enabled)')
+    sp_k4_decrypt = sub.add_parser("k4-decrypt", help="Decrypt K4 ciphertext")
+    sp_k4_decrypt.add_argument(
+        "--cipher", type=Path, default=None, help="Path to ciphertext file; omit to use K4 from config/config.json"
+    )
+    sp_k4_decrypt.add_argument("--limit", type=int, default=100, help="Candidate limit")
+    sp_k4_decrypt.add_argument("--adaptive", action="store_true", help="Enable adaptive mode")
+    sp_k4_decrypt.add_argument("--report", action="store_true", help="Emit report")
+    sp_k4_decrypt.add_argument(
+        "--no-auto-alphabet",
+        dest="try_all_alphabets",
+        action="store_false",
+        help="Disable alphabet auto-selection (default: enabled)",
+    )
     sp_k4_decrypt.set_defaults(func=cmd_k4_decrypt)
 
-    sp_sections_decrypt = sub.add_parser('sections-decrypt', help='Decrypt a section (K1, K2, K3, K4)')
-    sp_sections_decrypt.add_argument('--section', type=str, required=True, choices=['K1', 'K2', 'K3', 'K4'], help='Section to decrypt')
-    sp_sections_decrypt.add_argument('--cipher', type=Path, default=None, help='Path to ciphertext file; omit to use the section ciphertext from config/config.json')
-    sp_sections_decrypt.add_argument('--key', type=str, default=None, help='Key for K1/K2 (ignored for K3/K4)')
-    sp_sections_decrypt.add_argument('--json', action='store_true', help='Emit output as JSON (single line, no extra text)')
-    sp_sections_decrypt.add_argument('--explain', action='store_true', help='Show explainability metadata for the decryption (if available)')
+    sp_sections_decrypt = sub.add_parser("sections-decrypt", help="Decrypt a section (K1, K2, K3, K4)")
+    sp_sections_decrypt.add_argument(
+        "--section", type=str, required=True, choices=["K1", "K2", "K3", "K4"], help="Section to decrypt"
+    )
+    sp_sections_decrypt.add_argument(
+        "--cipher",
+        type=Path,
+        default=None,
+        help="Path to ciphertext file; omit to use the section ciphertext from config/config.json",
+    )
+    sp_sections_decrypt.add_argument("--key", type=str, default=None, help="Key for K1/K2 (ignored for K3/K4)")
+    sp_sections_decrypt.add_argument(
+        "--json", action="store_true", help="Emit output as JSON (single line, no extra text)"
+    )
+    sp_sections_decrypt.add_argument(
+        "--explain", action="store_true", help="Show explainability metadata for the decryption (if available)"
+    )
     sp_sections_decrypt.set_defaults(func=cmd_sections_decrypt)
 
-
-    sp_k4_attempts = sub.add_parser('k4-attempts', help='Persist current in-memory attempt logs')
-    sp_k4_attempts.add_argument('--label', type=str, default='k4', help='Label for attempt log file prefix')
+    sp_k4_attempts = sub.add_parser("k4-attempts", help="Persist current in-memory attempt logs")
+    sp_k4_attempts.add_argument("--label", type=str, default="k4", help="Label for attempt log file prefix")
     sp_k4_attempts.set_defaults(func=cmd_k4_attempts)
 
-    sp_tuning_sweep = sub.add_parser('tuning-crib-weight-sweep', help='Run crib weight sweep over provided weights')
-    sp_tuning_sweep.add_argument('--weights', type=str, default='0.5,1.0,1.5', help='Comma-separated weights')
-    sp_tuning_sweep.add_argument('--cribs', type=str, default='', help='Comma-separated crib tokens')
-    sp_tuning_sweep.add_argument('--samples', type=str, default='', help='Optional path to newline-delimited samples file')
-    sp_tuning_sweep.add_argument('--json', action='store_true', help='Emit JSON rows to stdout')
+    sp_tuning_sweep = sub.add_parser("tuning-crib-weight-sweep", help="Run crib weight sweep over provided weights")
+    sp_tuning_sweep.add_argument("--weights", type=str, default="0.5,1.0,1.5", help="Comma-separated weights")
+    sp_tuning_sweep.add_argument("--cribs", type=str, default="", help="Comma-separated crib tokens")
+    sp_tuning_sweep.add_argument(
+        "--samples", type=str, default="", help="Optional path to newline-delimited samples file"
+    )
+    sp_tuning_sweep.add_argument("--json", action="store_true", help="Emit JSON rows to stdout")
     sp_tuning_sweep.set_defaults(func=cmd_tuning_crib_weight_sweep)
 
-    sp_tuning_pick = sub.add_parser('tuning-pick-best', help='Pick best weight from a sweep CSV file')
-    sp_tuning_pick.add_argument('--csv', type=Path, required=True, help='Path to crib_weight_sweep.csv')
+    sp_tuning_pick = sub.add_parser("tuning-pick-best", help="Pick best weight from a sweep CSV file")
+    sp_tuning_pick.add_argument("--csv", type=Path, required=True, help="Path to crib_weight_sweep.csv")
     sp_tuning_pick.set_defaults(func=cmd_tuning_pick_best)
 
-    sp_tuning_summary = sub.add_parser('tuning-summarize-run', help='Clean, summarize, and count crib hits for a run dir')
-    sp_tuning_summary.add_argument('--run-dir', type=Path, required=True, help='Path to tuning run directory')
-    sp_tuning_summary.add_argument('--no-write', action='store_true', help='Do not write summary artifacts, just print JSON')
+    sp_tuning_summary = sub.add_parser(
+        "tuning-summarize-run", help="Clean, summarize, and count crib hits for a run dir"
+    )
+    sp_tuning_summary.add_argument("--run-dir", type=Path, required=True, help="Path to tuning run directory")
+    sp_tuning_summary.add_argument(
+        "--no-write", action="store_true", help="Do not write summary artifacts, just print JSON"
+    )
     sp_tuning_summary.set_defaults(func=cmd_tuning_summarize_run)
 
-    sp_tuning_tiny = sub.add_parser('tuning-tiny-param-sweep', help='Run tiny deterministic param sweep')
+    sp_tuning_tiny = sub.add_parser("tuning-tiny-param-sweep", help="Run tiny deterministic param sweep")
     sp_tuning_tiny.set_defaults(func=cmd_tuning_tiny_param_sweep)
 
-    sp_tuning_holdout = sub.add_parser('tuning-holdout-score', help='Compute holdout scoring deltas for a crib weight')
-    sp_tuning_holdout.add_argument('--weight', type=float, required=True, help='Crib weight to score')
-    sp_tuning_holdout.add_argument('--out', type=Path, default=Path('artifacts/reports/holdout.csv'), help='Output CSV path')
-    sp_tuning_holdout.add_argument('--no-write', action='store_true', help='Do not write CSV, just print JSON summary')
+    sp_tuning_holdout = sub.add_parser("tuning-holdout-score", help="Compute holdout scoring deltas for a crib weight")
+    sp_tuning_holdout.add_argument("--weight", type=float, required=True, help="Crib weight to score")
+    sp_tuning_holdout.add_argument(
+        "--out", type=Path, default=Path("artifacts/reports/holdout.csv"), help="Output CSV path"
+    )
+    sp_tuning_holdout.add_argument("--no-write", action="store_true", help="Do not write CSV, just print JSON summary")
     sp_tuning_holdout.set_defaults(func=cmd_tuning_holdout_score)
 
-    sp_spy_eval = sub.add_parser('spy-eval', help='Evaluate SPY thresholds and print metrics')
-    sp_spy_eval.add_argument('--labels', type=Path, default=Path('data/spy_eval_labels.csv'), help='Labels CSV path')
-    sp_spy_eval.add_argument('--runs', type=Path, default=Path('artifacts/tuning_runs'), help='Root runs directory')
-    sp_spy_eval.add_argument('--thresholds', type=str, default='0.0,0.25,0.5,0.75', help='Comma-separated thresholds')
+    sp_spy_eval = sub.add_parser("spy-eval", help="Evaluate SPY thresholds and print metrics")
+    sp_spy_eval.add_argument("--labels", type=Path, default=Path("data/spy_eval_labels.csv"), help="Labels CSV path")
+    sp_spy_eval.add_argument("--runs", type=Path, default=Path("artifacts/tuning_runs"), help="Root runs directory")
+    sp_spy_eval.add_argument("--thresholds", type=str, default="0.0,0.25,0.5,0.75", help="Comma-separated thresholds")
     sp_spy_eval.set_defaults(func=cmd_spy_eval)
 
-    sp_spy_extract = sub.add_parser('spy-extract', help='Extract SPY tokens from runs at min confidence')
-    sp_spy_extract.add_argument('--runs', type=Path, default=Path('artifacts/tuning_runs'), help='Root runs directory')
-    sp_spy_extract.add_argument('--min-conf', type=float, default=0.25, help='Minimum confidence threshold')
+    sp_spy_extract = sub.add_parser("spy-extract", help="Extract SPY tokens from runs at min confidence")
+    sp_spy_extract.add_argument("--runs", type=Path, default=Path("artifacts/tuning_runs"), help="Root runs directory")
+    sp_spy_extract.add_argument("--min-conf", type=float, default=0.25, help="Minimum confidence threshold")
     sp_spy_extract.set_defaults(func=cmd_spy_extract)
 
-    sp_tuning_report = sub.add_parser('tuning-report', help='Generate condensed CSV and top candidates markdown for a run')
-    sp_tuning_report.add_argument('--run-dir', type=Path, required=True, help='Path to tuning run directory')
-    sp_tuning_report.add_argument('--top-n', dest='top_n', type=int, default=10, help='Top candidates markdown limit')
-    sp_tuning_report.add_argument('--no-markdown', action='store_true', help='Skip markdown generation')
+    sp_tuning_report = sub.add_parser(
+        "tuning-report", help="Generate condensed CSV and top candidates markdown for a run"
+    )
+    sp_tuning_report.add_argument("--run-dir", type=Path, required=True, help="Path to tuning run directory")
+    sp_tuning_report.add_argument("--top-n", dest="top_n", type=int, default=10, help="Top candidates markdown limit")
+    sp_tuning_report.add_argument("--no-markdown", action="store_true", help="Skip markdown generation")
     sp_tuning_report.set_defaults(func=cmd_tuning_report)
 
-    sp_autopilot = sub.add_parser('autopilot', help='Run a single exchange or loop until safe decision')
-    sp_autopilot.add_argument('--plan', type=str, default=None, help='Optional plan text appended to Q prompt')
-    sp_autopilot.add_argument('--dry-run', action='store_true', help='Dry-run (no destructive actions)')
-    sp_autopilot.add_argument('--loop', action='store_true', help='Loop until safe decision or iterations cap')
-    sp_autopilot.add_argument('--iterations', type=int, default=0, help='Loop iteration cap (0=infinite)')
-    sp_autopilot.add_argument('--interval', type=int, default=300, help='Seconds between loop iterations')
-    sp_autopilot.add_argument('--force', action='store_true', help='Override dry-run inside loop')
+    sp_autopilot = sub.add_parser("autopilot", help="Run a single exchange or loop until safe decision")
+    sp_autopilot.add_argument("--plan", type=str, default=None, help="Optional plan text appended to Q prompt")
+    sp_autopilot.add_argument("--dry-run", action="store_true", help="Dry-run (no destructive actions)")
+    sp_autopilot.add_argument("--loop", action="store_true", help="Loop until safe decision or iterations cap")
+    sp_autopilot.add_argument("--iterations", type=int, default=0, help="Loop iteration cap (0=infinite)")
+    sp_autopilot.add_argument("--interval", type=int, default=300, help="Seconds between loop iterations")
+    sp_autopilot.add_argument("--force", action="store_true", help="Override dry-run inside loop")
     sp_autopilot.set_defaults(func=cmd_autopilot)
 
-    sp_autonomous = sub.add_parser('autonomous', help='Run autonomous coordination loop (24/7 cryptanalysis)')
-    sp_autonomous.add_argument('--max-hours', type=float, default=None, help='Maximum runtime in hours (None=infinite)')
-    sp_autonomous.add_argument('--max-cycles', type=int, default=None, help='Maximum coordination cycles (None=infinite)')
-    sp_autonomous.add_argument('--cycle-interval', type=float, default=0.25, help='Minutes between cycles (default: 15 sec)')
-    sp_autonomous.add_argument('--ops-cycle', type=float, default=0.5, help='Minutes between OPS strategic analyses (default: 30 sec)')
-    sp_autonomous.add_argument('--web-intel-hours', type=float, default=0.5, help='Hours between web intelligence checks (default: 30 min)')
+    sp_autonomous = sub.add_parser("autonomous", help="Run autonomous coordination loop (24/7 cryptanalysis)")
+    sp_autonomous.add_argument("--max-hours", type=float, default=None, help="Maximum runtime in hours (None=infinite)")
+    sp_autonomous.add_argument(
+        "--max-cycles", type=int, default=None, help="Maximum coordination cycles (None=infinite)"
+    )
+    sp_autonomous.add_argument(
+        "--cycle-interval", type=float, default=0.25, help="Minutes between cycles (default: 15 sec)"
+    )
+    sp_autonomous.add_argument(
+        "--ops-cycle", type=float, default=0.5, help="Minutes between OPS strategic analyses (default: 30 sec)"
+    )
+    sp_autonomous.add_argument(
+        "--web-intel-hours", type=float, default=0.5, help="Hours between web intelligence checks (default: 30 min)"
+    )
     sp_autonomous.set_defaults(func=cmd_autonomous)
 
-    sp_examples_smoke = sub.add_parser('examples-smoke', help='Run fast example demos (sections, tiny sweep, composite) for CI smoke validation')
-    sp_examples_smoke.add_argument('--limit', type=int, default=5, help='Composite demo candidate limit')
-    sp_examples_smoke.add_argument('--keep', type=int, default=4, help='Max number of recent demo dirs to keep after run (purge older)')
+    sp_examples_smoke = sub.add_parser(
+        "examples-smoke", help="Run fast example demos (sections, tiny sweep, composite) for CI smoke validation"
+    )
+    sp_examples_smoke.add_argument("--limit", type=int, default=5, help="Composite demo candidate limit")
+    sp_examples_smoke.add_argument(
+        "--keep", type=int, default=4, help="Max number of recent demo dirs to keep after run (purge older)"
+    )
     sp_examples_smoke.set_defaults(func=cmd_examples_smoke)
 
     sp_keyspace_stats = sub.add_parser(
-        'keyspace-stats',
-        help='Show keyspace coverage heatmap and attack prioritisation recommendations',
+        "keyspace-stats",
+        help="Show keyspace coverage heatmap and attack prioritisation recommendations",
     )
     sp_keyspace_stats.add_argument(
-        '--cipher', type=str, default=None,
+        "--cipher",
+        type=str,
+        default=None,
         help='Cipher type to report on (e.g. "vigenere"). Omit for all types.',
     )
     sp_keyspace_stats.add_argument(
-        '--top-n', dest='top_n', type=int, default=5,
-        help='Number of priority recommendations to display (default: 5)',
+        "--top-n",
+        dest="top_n",
+        type=int,
+        default=5,
+        help="Number of priority recommendations to display (default: 5)",
     )
     sp_keyspace_stats.add_argument(
-        '--json', action='store_true',
-        help='Emit machine-readable JSON instead of human-readable table',
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human-readable table",
     )
     sp_keyspace_stats.set_defaults(func=cmd_keyspace_stats)
 
     return parser
 
+    p = argparse.ArgumentParser(prog="kryptos", description="Kryptos research CLI")
+    p.add_argument("--log-level", type=str, default="INFO", help="Logging level (DEBUG, INFO, WARNING, ERROR)")
+    p.add_argument("--quiet", action="store_true", help="Suppress non-error logging (JSON output only)")
+    sub = p.add_subparsers(dest="command", required=True)
 
-    p = argparse.ArgumentParser(prog='kryptos', description='Kryptos research CLI')
-    p.add_argument('--log-level', type=str, default='INFO', help='Logging level (DEBUG, INFO, WARNING, ERROR)')
-    p.add_argument('--quiet', action='store_true', help='Suppress non-error logging (JSON output only)')
-    sub = p.add_subparsers(dest='command', required=True)
-
-    sp_sections = sub.add_parser('sections', help='List available sections (K1-K4)')
+    sp_sections = sub.add_parser("sections", help="List available sections (K1-K4)")
     sp_sections.set_defaults(func=cmd_sections)
 
-    sp_k4 = sub.add_parser('k4-decrypt', help='Run composite K4 decrypt search')
-    sp_k4.add_argument('--cipher', type=Path, required=True, help='Path to ciphertext file (raw)')
-    sp_k4.add_argument('--limit', type=int, default=50, help='Candidate limit')
-    sp_k4.add_argument('--adaptive', action='store_true', help='Enable adaptive fusion weighting')
-    sp_k4.add_argument('--report', action='store_true', help='Write artifacts (candidates + attempts)')
+    sp_k4 = sub.add_parser("k4-decrypt", help="Run composite K4 decrypt search")
+    sp_k4.add_argument("--cipher", type=Path, required=True, help="Path to ciphertext file (raw)")
+    sp_k4.add_argument("--limit", type=int, default=50, help="Candidate limit")
+    sp_k4.add_argument("--adaptive", action="store_true", help="Enable adaptive fusion weighting")
+    sp_k4.add_argument("--report", action="store_true", help="Write artifacts (candidates + attempts)")
     sp_k4.set_defaults(func=cmd_k4_decrypt)
 
-    sp_attempts = sub.add_parser('k4-attempts', help='Persist current in-memory attempt logs')
-    sp_attempts.add_argument('--label', type=str, default='k4', help='Label for attempt log file prefix')
+    sp_attempts = sub.add_parser("k4-attempts", help="Persist current in-memory attempt logs")
+    sp_attempts.add_argument("--label", type=str, default="k4", help="Label for attempt log file prefix")
     sp_attempts.set_defaults(func=cmd_k4_attempts)
 
-    sp_tuning_sweep = sub.add_parser('tuning-crib-weight-sweep', help='Run crib weight sweep over provided weights')
-    sp_tuning_sweep.add_argument('--weights', type=str, default='0.5,1.0,1.5', help='Comma-separated weights')
-    sp_tuning_sweep.add_argument('--cribs', type=str, default='', help='Comma-separated crib tokens')
+    sp_tuning_sweep = sub.add_parser("tuning-crib-weight-sweep", help="Run crib weight sweep over provided weights")
+    sp_tuning_sweep.add_argument("--weights", type=str, default="0.5,1.0,1.5", help="Comma-separated weights")
+    sp_tuning_sweep.add_argument("--cribs", type=str, default="", help="Comma-separated crib tokens")
     sp_tuning_sweep.add_argument(
-        '--samples',
+        "--samples",
         type=str,
-        default='',
-        help='Optional path to newline-delimited samples file',
+        default="",
+        help="Optional path to newline-delimited samples file",
     )
-    sp_tuning_sweep.add_argument('--json', action='store_true', help='Emit JSON rows to stdout')
+    sp_tuning_sweep.add_argument("--json", action="store_true", help="Emit JSON rows to stdout")
     sp_tuning_sweep.set_defaults(func=cmd_tuning_crib_weight_sweep)
 
-    sp_tuning_pick = sub.add_parser('tuning-pick-best', help='Pick best weight from a sweep CSV file')
-    sp_tuning_pick.add_argument('--csv', type=Path, required=True, help='Path to crib_weight_sweep.csv')
+    sp_tuning_pick = sub.add_parser("tuning-pick-best", help="Pick best weight from a sweep CSV file")
+    sp_tuning_pick.add_argument("--csv", type=Path, required=True, help="Path to crib_weight_sweep.csv")
     sp_tuning_pick.set_defaults(func=cmd_tuning_pick_best)
 
     sp_tuning_summary = sub.add_parser(
-        'tuning-summarize-run',
-        help='Clean, summarize, and count crib hits for a run dir',
+        "tuning-summarize-run",
+        help="Clean, summarize, and count crib hits for a run dir",
     )
-    sp_tuning_summary.add_argument('--run-dir', type=Path, required=True, help='Path to tuning run directory')
+    sp_tuning_summary.add_argument("--run-dir", type=Path, required=True, help="Path to tuning run directory")
     sp_tuning_summary.add_argument(
-        '--no-write',
-        action='store_true',
-        help='Do not write summary artifacts, just print JSON',
+        "--no-write",
+        action="store_true",
+        help="Do not write summary artifacts, just print JSON",
     )
     sp_tuning_summary.set_defaults(func=cmd_tuning_summarize_run)
 
-    sp_tuning_tiny = sub.add_parser('tuning-tiny-param-sweep', help='Run tiny deterministic param sweep')
+    sp_tuning_tiny = sub.add_parser("tuning-tiny-param-sweep", help="Run tiny deterministic param sweep")
     sp_tuning_tiny.set_defaults(func=cmd_tuning_tiny_param_sweep)
 
-    sp_tuning_holdout = sub.add_parser('tuning-holdout-score', help='Compute holdout scoring deltas for a crib weight')
-    sp_tuning_holdout.add_argument('--weight', type=float, required=True, help='Crib weight to score')
+    sp_tuning_holdout = sub.add_parser("tuning-holdout-score", help="Compute holdout scoring deltas for a crib weight")
+    sp_tuning_holdout.add_argument("--weight", type=float, required=True, help="Crib weight to score")
     sp_tuning_holdout.add_argument(
-        '--out',
+        "--out",
         type=Path,
-        default=Path('artifacts/reports/holdout.csv'),
-        help='Output CSV path',
+        default=Path("artifacts/reports/holdout.csv"),
+        help="Output CSV path",
     )
     sp_tuning_holdout.add_argument(
-        '--no-write',
-        action='store_true',
-        help='Do not write CSV, just print JSON summary',
+        "--no-write",
+        action="store_true",
+        help="Do not write CSV, just print JSON summary",
     )
     sp_tuning_holdout.set_defaults(func=cmd_tuning_holdout_score)
 
-    sp_spy_eval = sub.add_parser('spy-eval', help='Evaluate SPY thresholds and print metrics')
-    sp_spy_eval.add_argument('--labels', type=Path, default=Path('data/spy_eval_labels.csv'), help='Labels CSV path')
-    sp_spy_eval.add_argument('--runs', type=Path, default=Path('artifacts/tuning_runs'), help='Root runs directory')
-    sp_spy_eval.add_argument('--thresholds', type=str, default='0.0,0.25,0.5,0.75', help='Comma-separated thresholds')
+    sp_spy_eval = sub.add_parser("spy-eval", help="Evaluate SPY thresholds and print metrics")
+    sp_spy_eval.add_argument("--labels", type=Path, default=Path("data/spy_eval_labels.csv"), help="Labels CSV path")
+    sp_spy_eval.add_argument("--runs", type=Path, default=Path("artifacts/tuning_runs"), help="Root runs directory")
+    sp_spy_eval.add_argument("--thresholds", type=str, default="0.0,0.25,0.5,0.75", help="Comma-separated thresholds")
     sp_spy_eval.set_defaults(func=cmd_spy_eval)
 
-    sp_spy_extract = sub.add_parser('spy-extract', help='Extract SPY tokens from runs at min confidence')
-    sp_spy_extract.add_argument('--runs', type=Path, default=Path('artifacts/tuning_runs'), help='Root runs directory')
-    sp_spy_extract.add_argument('--min-conf', type=float, default=0.25, help='Minimum confidence threshold')
+    sp_spy_extract = sub.add_parser("spy-extract", help="Extract SPY tokens from runs at min confidence")
+    sp_spy_extract.add_argument("--runs", type=Path, default=Path("artifacts/tuning_runs"), help="Root runs directory")
+    sp_spy_extract.add_argument("--min-conf", type=float, default=0.25, help="Minimum confidence threshold")
     sp_spy_extract.set_defaults(func=cmd_spy_extract)
 
     sp_tuning_report = sub.add_parser(
-        'tuning-report',
-        help='Generate condensed CSV and top candidates markdown for a run',
+        "tuning-report",
+        help="Generate condensed CSV and top candidates markdown for a run",
     )
-    sp_tuning_report.add_argument('--run-dir', type=Path, required=True, help='Path to tuning run directory')
-    sp_tuning_report.add_argument('--top-n', dest='top_n', type=int, default=10, help='Top candidates markdown limit')
-    sp_tuning_report.add_argument('--no-markdown', action='store_true', help='Skip markdown generation')
+    sp_tuning_report.add_argument("--run-dir", type=Path, required=True, help="Path to tuning run directory")
+    sp_tuning_report.add_argument("--top-n", dest="top_n", type=int, default=10, help="Top candidates markdown limit")
+    sp_tuning_report.add_argument("--no-markdown", action="store_true", help="Skip markdown generation")
     sp_tuning_report.set_defaults(func=cmd_tuning_report)
 
-    sp_autopilot = sub.add_parser('autopilot', help='Run a single exchange or loop until safe decision')
-    sp_autopilot.add_argument('--plan', type=str, default=None, help='Optional plan text appended to Q prompt')
-    sp_autopilot.add_argument('--dry-run', action='store_true', help='Dry-run (no destructive actions)')
-    sp_autopilot.add_argument('--loop', action='store_true', help='Loop until safe decision or iterations cap')
-    sp_autopilot.add_argument('--iterations', type=int, default=0, help='Loop iteration cap (0=infinite)')
-    sp_autopilot.add_argument('--interval', type=int, default=300, help='Seconds between loop iterations')
-    sp_autopilot.add_argument('--force', action='store_true', help='Override dry-run inside loop')
+    sp_autopilot = sub.add_parser("autopilot", help="Run a single exchange or loop until safe decision")
+    sp_autopilot.add_argument("--plan", type=str, default=None, help="Optional plan text appended to Q prompt")
+    sp_autopilot.add_argument("--dry-run", action="store_true", help="Dry-run (no destructive actions)")
+    sp_autopilot.add_argument("--loop", action="store_true", help="Loop until safe decision or iterations cap")
+    sp_autopilot.add_argument("--iterations", type=int, default=0, help="Loop iteration cap (0=infinite)")
+    sp_autopilot.add_argument("--interval", type=int, default=300, help="Seconds between loop iterations")
+    sp_autopilot.add_argument("--force", action="store_true", help="Override dry-run inside loop")
     sp_autopilot.set_defaults(func=cmd_autopilot)
 
-    sp_autonomous = sub.add_parser('autonomous', help='Run autonomous coordination loop (24/7 cryptanalysis)')
-    sp_autonomous.add_argument('--max-hours', type=float, default=None, help='Maximum runtime in hours (None=infinite)')
+    sp_autonomous = sub.add_parser("autonomous", help="Run autonomous coordination loop (24/7 cryptanalysis)")
+    sp_autonomous.add_argument("--max-hours", type=float, default=None, help="Maximum runtime in hours (None=infinite)")
     sp_autonomous.add_argument(
-        '--max-cycles',
+        "--max-cycles",
         type=int,
         default=None,
-        help='Maximum coordination cycles (None=infinite)',
+        help="Maximum coordination cycles (None=infinite)",
     )
     sp_autonomous.add_argument(
-        '--cycle-interval',
+        "--cycle-interval",
         type=float,
         default=0.25,
-        help='Minutes between cycles (default: 15 sec)',
+        help="Minutes between cycles (default: 15 sec)",
     )
     sp_autonomous.add_argument(
-        '--ops-cycle',
+        "--ops-cycle",
         type=float,
         default=0.5,
-        help='Minutes between OPS strategic analyses (default: 30 sec)',
+        help="Minutes between OPS strategic analyses (default: 30 sec)",
     )
     sp_autonomous.add_argument(
-        '--web-intel-hours',
+        "--web-intel-hours",
         type=float,
         default=0.5,
-        help='Hours between web intelligence checks (default: 30 min)',
+        help="Hours between web intelligence checks (default: 30 min)",
     )
     sp_autonomous.set_defaults(func=cmd_autonomous)
 
     sp_examples_smoke = sub.add_parser(
-        'examples-smoke',
-        help='Run fast example demos (sections, tiny sweep, composite) for CI smoke validation',
+        "examples-smoke",
+        help="Run fast example demos (sections, tiny sweep, composite) for CI smoke validation",
     )
-    sp_examples_smoke.add_argument('--limit', type=int, default=5, help='Composite demo candidate limit')
+    sp_examples_smoke.add_argument("--limit", type=int, default=5, help="Composite demo candidate limit")
     sp_examples_smoke.add_argument(
-        '--keep',
+        "--keep",
         type=int,
         default=4,
-        help='Max number of recent demo dirs to keep after run (purge older)',
+        help="Max number of recent demo dirs to keep after run (purge older)",
     )
     sp_examples_smoke.set_defaults(func=cmd_examples_smoke)
     return p
@@ -406,6 +442,7 @@ def build_parser() -> argparse.ArgumentParser:
 def cmd_keyspace_stats(args: argparse.Namespace) -> int:
     """Print a keyspace coverage heatmap and attack prioritisation table."""
     import json as _json
+
     from kryptos.provenance.search_space import SearchSpaceTracker
 
     tracker = SearchSpaceTracker()
@@ -419,13 +456,17 @@ def cmd_keyspace_stats(args: argparse.Namespace) -> int:
     # Human-readable output
     print("\n=== Keyspace Coverage ===")
     for ct, data in report.get("cipher_types", {}).items():
-        print(f"\n{ct}  (overall {data['overall_coverage']:.1f}%  |  "
-              f"{data['total_explored']:,}/{data['total_size']:,} explored)")
+        print(
+            f"\n{ct}  (overall {data['overall_coverage']:.1f}%  |  "
+            f"{data['total_explored']:,}/{data['total_size']:,} explored)"
+        )
         for r in data.get("regions", []):
             bar_fill = int(r["coverage_percent"] / 5)
             bar = "#" * bar_fill + "." * (20 - bar_fill)
-            print(f"  {r['region']:20s} [{bar}] {r['coverage_percent']:5.1f}%  "
-                  f"({r['explored_count']:,}/{r['total_size']:,})")
+            print(
+                f"  {r['region']:20s} [{bar}] {r['coverage_percent']:5.1f}%  "
+                f"({r['explored_count']:,}/{r['total_size']:,})"
+            )
 
     if not report.get("cipher_types"):
         print("  (no regions registered yet — run a campaign to populate)")
@@ -434,8 +475,10 @@ def cmd_keyspace_stats(args: argparse.Namespace) -> int:
     if not recs:
         print("  (no data yet)")
     for i, rec in enumerate(recs, 1):
-        print(f"  {i}. [{rec['cipher_type']} / {rec['region']}]  score={rec['adjusted_score']:.1f}  "
-              f"coverage={rec['coverage']:.1f}%")
+        print(
+            f"  {i}. [{rec['cipher_type']} / {rec['region']}]  score={rec['adjusted_score']:.1f}  "
+            f"coverage={rec['coverage']:.1f}%"
+        )
         print(f"     {rec['reason']}  |  tried_keys={rec['tried_key_count']}")
     print()
     return 0
@@ -445,10 +488,10 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     # Only set log level if present
-    level = getattr(logging, getattr(args, 'log_level', 'INFO').upper(), logging.INFO)
-    logger = setup_logging(logger_name='kryptos.cli')
+    level = getattr(logging, getattr(args, "log_level", "INFO").upper(), logging.INFO)
+    logger = setup_logging(logger_name="kryptos.cli")
     logger.setLevel(level)
-    if hasattr(args, 'quiet') and args.quiet:
+    if hasattr(args, "quiet") and args.quiet:
         logger.setLevel(logging.ERROR)
     return args.func(args)
 
@@ -456,13 +499,13 @@ def main(argv: list[str] | None = None) -> int:
 def _load_samples(path: Path) -> list[str]:
     if not path or not path.exists():
         return []
-    return [line.strip() for line in path.read_text(encoding='utf-8').splitlines() if line.strip()]
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
 def cmd_tuning_crib_weight_sweep(args: argparse.Namespace) -> int:
-    logger = setup_logging(logger_name='kryptos.cli')
-    weights = [float(w) for w in args.weights.split(',') if w.strip()]
-    cribs = [c.strip().upper() for c in args.cribs.split(',') if c.strip()]
+    logger = setup_logging(logger_name="kryptos.cli")
+    weights = [float(w) for w in args.weights.split(",") if w.strip()]
+    cribs = [c.strip().upper() for c in args.cribs.split(",") if c.strip()]
     samples = _load_samples(Path(args.samples)) if args.samples else None
     rows = run_crib_weight_sweep(samples=samples, cribs=cribs, weights=weights)
     if args.json:
@@ -474,14 +517,14 @@ def cmd_tuning_crib_weight_sweep(args: argparse.Namespace) -> int:
 
 
 def cmd_tuning_pick_best(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     if not args.csv.exists():
-        print(json.dumps({'error': 'csv_not_found', 'path': str(args.csv)}))
+        print(json.dumps({"error": "csv_not_found", "path": str(args.csv)}))
         return 2
     import csv
 
     rows: list[WeightSweepRow] = []
-    with args.csv.open('r', encoding='utf-8') as fh:
+    with args.csv.open("r", encoding="utf-8") as fh:
         reader = csv.reader(fh)
         next(reader, None)
         for row in reader:
@@ -504,14 +547,14 @@ def cmd_tuning_pick_best(args: argparse.Namespace) -> int:
                 ),
             )
     best = pick_best_weight_from_rows(rows)
-    print(json.dumps({'best_weight': best}))
+    print(json.dumps({"best_weight": best}))
     return 0
 
 
 def cmd_tuning_summarize_run(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     if not args.run_dir.exists() or not args.run_dir.is_dir():
-        print(json.dumps({'error': 'run_dir_not_found', 'path': str(args.run_dir)}))
+        print(json.dumps({"error": "run_dir_not_found", "path": str(args.run_dir)}))
         return 2
     res = end_to_end_process(args.run_dir, write=not args.no_write)
     print(json.dumps(res, indent=2))
@@ -519,103 +562,103 @@ def cmd_tuning_summarize_run(args: argparse.Namespace) -> int:
 
 
 def cmd_tuning_tiny_param_sweep(_args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     rows = tiny_param_sweep()
     print(json.dumps(rows, indent=2))
     return 0
 
 
 def cmd_tuning_holdout_score(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     holdout_samples = [
-        'IN THE QUIET AFTERNOON THE SHADOWS GREW LONG ON THE FLOOR',
-        'THE SECRET MESSAGE WAS HIDDEN IN PLAIN SIGHT AMONG THE TEXT',
+        "IN THE QUIET AFTERNOON THE SHADOWS GREW LONG ON THE FLOOR",
+        "THE SECRET MESSAGE WAS HIDDEN IN PLAIN SIGHT AMONG THE TEXT",
     ]
     chosen_w = float(args.weight)
     rows = []
     for s in holdout_samples:
         base = k4_scoring.combined_plaintext_score(s)
         withc = k4_scoring.combined_plaintext_score_with_external_cribs(s, external_cribs=[], crib_weight=chosen_w)
-        rows.append({'sample': s, 'base': base, 'with': withc, 'delta': withc - base})
+        rows.append({"sample": s, "base": base, "with": withc, "delta": withc - base})
 
-    mean_delta = sum(r['delta'] for r in rows) / len(rows) if rows else None
-    out = {'weight': chosen_w, 'mean_delta': mean_delta, 'rows': rows}
+    mean_delta = sum(r["delta"] for r in rows) / len(rows) if rows else None
+    out = {"weight": chosen_w, "mean_delta": mean_delta, "rows": rows}
     if args.no_write:
         print(json.dumps(out, indent=2))
         return 0
     args.out.parent.mkdir(parents=True, exist_ok=True)
     import csv
 
-    with args.out.open('w', newline='', encoding='utf-8') as fh:
-        w = csv.DictWriter(fh, fieldnames=['sample', 'base', 'with', 'delta'])
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=["sample", "base", "with", "delta"])
         w.writeheader()
         for r in rows:
             w.writerow(r)
     print(json.dumps(out, indent=2))
-    if not getattr(args, 'quiet', False):
+    if not getattr(args, "quiet", False):
         print(str(args.out))
     return 0
 
 
 def cmd_spy_eval(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
-    thresholds = [float(t) for t in args.thresholds.split(',') if t.strip()]
+    setup_logging(logger_name="kryptos.cli")
+    thresholds = [float(t) for t in args.thresholds.split(",") if t.strip()]
     eval_res = spy_eval.evaluate(args.labels, args.runs, thresholds=thresholds)
     best = spy_eval.select_best_threshold(args.labels, args.runs, thresholds)
     out = {
-        'thresholds': {f"{th:.2f}": {'precision': p, 'recall': r, 'f1': f1} for th, (p, r, f1) in eval_res.items()},
-        'best_threshold': best,
+        "thresholds": {f"{th:.2f}": {"precision": p, "recall": r, "f1": f1} for th, (p, r, f1) in eval_res.items()},
+        "best_threshold": best,
     }
     print(json.dumps(out, indent=2))
     return 0
 
 
 def cmd_spy_extract(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     tokens_by_run = {}
     for run_dir in args.runs.iterdir():
-        if run_dir.is_dir() and run_dir.name.startswith('run_'):
+        if run_dir.is_dir() and run_dir.name.startswith("run_"):
             matches = spy_module_extract(min_conf=args.min_conf, run_dir=run_dir)
             if matches:
                 tokens_by_run[run_dir.name] = sorted({t for m in matches for t in m.tokens})
-    print(json.dumps({'min_conf': args.min_conf, 'extracted': tokens_by_run}, indent=2))
+    print(json.dumps({"min_conf": args.min_conf, "extracted": tokens_by_run}, indent=2))
     return 0
 
 
 def cmd_tuning_report(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     if not args.run_dir.exists() or not args.run_dir.is_dir():
-        print(json.dumps({'error': 'run_dir_not_found', 'path': str(args.run_dir)}))
+        print(json.dumps({"error": "run_dir_not_found", "path": str(args.run_dir)}))
         return 2
     condensed_path = write_condensed_report(args.run_dir)
     md_path = None
     if not args.no_markdown:
         md_path = write_top_candidates_markdown(args.run_dir, top_n=args.top_n)
-    out = {'condensed_csv': str(condensed_path), 'markdown': str(md_path) if md_path else None}
+    out = {"condensed_csv": str(condensed_path), "markdown": str(md_path) if md_path else None}
     print(json.dumps(out, indent=2))
     return 0
 
 
 def cmd_autopilot(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     if args.loop:
         code = autopilot_mod.run_autopilot_loop(
             iterations=args.iterations,
             interval=args.interval,
             plan=args.plan,
         )
-        print(json.dumps({'mode': 'loop', 'exit_code': code}))
+        print(json.dumps({"mode": "loop", "exit_code": code}))
         return code
     path = autopilot_mod.run_exchange(plan_text=args.plan, autopilot=True)
-    print(json.dumps({'mode': 'single', 'log_path': str(path)}))
+    print(json.dumps({"mode": "single", "log_path": str(path)}))
     return 0
 
 
 def cmd_autonomous(args: argparse.Namespace) -> int:
     from kryptos.autonomous_coordinator import AutonomousCoordinator
 
-    logger = setup_logging(logger_name='kryptos.cli')
-    logger.info('🚀 Starting autonomous coordination system')
+    logger = setup_logging(logger_name="kryptos.cli")
+    logger.info("🚀 Starting autonomous coordination system")
 
     coordinator = AutonomousCoordinator(
         ops_cycle_minutes=args.ops_cycle,
@@ -630,34 +673,34 @@ def cmd_autonomous(args: argparse.Namespace) -> int:
         )
         return 0
     except KeyboardInterrupt:
-        logger.info('⚠️  Interrupted by user')
+        logger.info("⚠️  Interrupted by user")
         return 130
     except Exception as exc:
-        logger.exception('❌ Autonomous coordination failed: %s', exc)
+        logger.exception("❌ Autonomous coordination failed: %s", exc)
         return 1
 
 
 def cmd_examples_smoke(args: argparse.Namespace) -> int:
-    setup_logging(logger_name='kryptos.cli')
+    setup_logging(logger_name="kryptos.cli")
     try:
         sections = run_sections_demo()
         sweep_dir = run_tiny_weight_sweep()
         composite_dir = run_composite_demo(limit=args.limit)
         purge_res = purge_demo_artifacts(max_keep=args.keep)
     except Exception as exc:
-        print(json.dumps({'status': 'error', 'error': repr(exc)}))
+        print(json.dumps({"status": "error", "error": repr(exc)}))
         return 2
     out = {
-        'status': 'ok',
-        'sections': [s['name'] for s in sections],
-        'tiny_weight_sweep_dir': str(sweep_dir),
-        'composite_dir': composite_dir,
-        'purged': [p.name for p in purge_res.removed],
-        'kept': [p.name for p in purge_res.kept],
+        "status": "ok",
+        "sections": [s["name"] for s in sections],
+        "tiny_weight_sweep_dir": str(sweep_dir),
+        "composite_dir": composite_dir,
+        "purged": [p.name for p in purge_res.removed],
+        "kept": [p.name for p in purge_res.kept],
     }
     print(json.dumps(out, indent=2))
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/kryptos/cli/main.py
+++ b/src/kryptos/cli/main.py
@@ -300,6 +300,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sp_keyspace_stats.set_defaults(func=cmd_keyspace_stats)
 
+    sp_serve = sub.add_parser("serve", help="Run the Kryptos FastAPI server (turbovec RAG search over artifacts/)")
+    sp_serve.add_argument("--host", type=str, default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
+    sp_serve.add_argument("--port", type=int, default=8000, help="Bind port (default: 8000)")
+    sp_serve.add_argument("--reload", action="store_true", help="Enable auto-reload (development)")
+    sp_serve.set_defaults(func=cmd_serve)
+
     return parser
 
     p = argparse.ArgumentParser(prog="kryptos", description="Kryptos research CLI")
@@ -437,6 +443,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sp_examples_smoke.set_defaults(func=cmd_examples_smoke)
     return p
+
+
+def cmd_serve(args: argparse.Namespace) -> int:
+    """Run the Kryptos FastAPI server (turbovec RAG search over artifacts/)."""
+    import uvicorn
+
+    uvicorn.run("kryptos.api.app:app", host=args.host, port=args.port, reload=args.reload)
+    return 0
 
 
 def cmd_keyspace_stats(args: argparse.Namespace) -> int:

--- a/src/kryptos/paths.py
+++ b/src/kryptos/paths.py
@@ -6,6 +6,8 @@ Primary helpers (cached):
     get_logs_dir() -> Path
     get_decisions_dir() -> Path
     get_tuning_runs_root() -> Path
+    get_data_root() -> Path
+    get_turbovec_index_dir() -> Path
     ensure_reports_dir() -> Path
     provenance_hash(text: str, meta: dict) -> str
     get_provenance_info() -> dict
@@ -90,6 +92,19 @@ def get_tuning_runs_root() -> Path:
     return runs
 
 
+def get_data_root() -> Path:
+    root = get_repo_root()
+    data = root / "data"
+    data.mkdir(parents=True, exist_ok=True)
+    return data
+
+
+def get_turbovec_index_dir() -> Path:
+    idx = get_data_root() / "turbovec"
+    idx.mkdir(parents=True, exist_ok=True)
+    return idx
+
+
 def ensure_reports_dir(ts: str | None = None) -> Path:
     root = get_artifacts_root()
     date_seg = datetime.now(timezone.utc).strftime("%Y%m%d")
@@ -114,7 +129,7 @@ def provenance_hash(text: str, meta: dict) -> str:
 
 
 def get_provenance_info(include_params: dict | None = None) -> dict:
-    info = {
+    info: dict[str, object] = {
         "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "python_version": sys.version,
         "python_version_info": {
@@ -189,6 +204,8 @@ __all__ = [
     "get_logs_dir",
     "get_decisions_dir",
     "get_tuning_runs_root",
+    "get_data_root",
+    "get_turbovec_index_dir",
     "ensure_reports_dir",
     "provenance_hash",
     "get_provenance_info",

--- a/src/kryptos/rag/__init__.py
+++ b/src/kryptos/rag/__init__.py
@@ -1,0 +1,10 @@
+"""Turbovec-backed RAG over `artifacts/` (cipher/hypothesis search).
+
+See AI_STACK_STRATEGY "Now" item #1: an embedded, in-process vector index
+over the locally-generated `artifacts/` tree (search results, decisions,
+hypotheses, logs) — no server/daemon, no migrations.
+"""
+
+from kryptos.rag.index import ArtifactIndex, SearchResult
+
+__all__ = ["ArtifactIndex", "SearchResult"]

--- a/src/kryptos/rag/chunking.py
+++ b/src/kryptos/rag/chunking.py
@@ -1,0 +1,63 @@
+"""Walk `artifacts/` and split JSON/Markdown files into text chunks for embedding."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+INDEXABLE_SUFFIXES = {".json", ".md"}
+MAX_FILE_BYTES = 256_000
+CHUNK_SIZE = 1000
+CHUNK_OVERLAP = 100
+
+
+@dataclass(frozen=True)
+class ArtifactChunk:
+    path: str
+    chunk_index: int
+    text: str
+
+
+def _file_text(path: Path) -> str | None:
+    if path.suffix == ".md":
+        return path.read_text(encoding="utf-8", errors="ignore")
+    if path.suffix == ".json":
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        return json.dumps(data, indent=2, ensure_ascii=False)
+    return None
+
+
+def _split_chunks(text: str, size: int = CHUNK_SIZE, overlap: int = CHUNK_OVERLAP) -> Iterator[str]:
+    text = text.strip()
+    if not text:
+        return
+    step = size - overlap
+    for start in range(0, len(text), step):
+        end = start + size
+        chunk = text[start:end].strip()
+        if chunk:
+            yield chunk
+        if end >= len(text):
+            break
+
+
+def iter_artifact_chunks(artifacts_root: Path) -> Iterator[ArtifactChunk]:
+    """Yield text chunks for every indexable file under *artifacts_root*."""
+    if not artifacts_root.is_dir():
+        return
+    for path in sorted(artifacts_root.rglob("*")):
+        if not path.is_file() or path.suffix not in INDEXABLE_SUFFIXES:
+            continue
+        if path.stat().st_size > MAX_FILE_BYTES:
+            continue
+        text = _file_text(path)
+        if not text:
+            continue
+        rel = path.relative_to(artifacts_root).as_posix()
+        for chunk_index, chunk in enumerate(_split_chunks(text)):
+            yield ArtifactChunk(path=rel, chunk_index=chunk_index, text=chunk)

--- a/src/kryptos/rag/embeddings.py
+++ b/src/kryptos/rag/embeddings.py
@@ -1,0 +1,26 @@
+"""Sentence-transformer embeddings for the turbovec RAG index."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import numpy as np
+
+DEFAULT_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+@lru_cache(maxsize=1)
+def _load_model(model_name: str):
+    from sentence_transformers import SentenceTransformer
+
+    return SentenceTransformer(model_name)
+
+
+def embed_texts(texts: list[str], model_name: str = DEFAULT_MODEL_NAME) -> np.ndarray:
+    model = _load_model(model_name)
+    vectors = model.encode(texts, show_progress_bar=False, convert_to_numpy=True)
+    return np.asarray(vectors, dtype=np.float32)
+
+
+def embed_query(text: str, model_name: str = DEFAULT_MODEL_NAME) -> np.ndarray:
+    return embed_texts([text], model_name)[0]

--- a/src/kryptos/rag/index.py
+++ b/src/kryptos/rag/index.py
@@ -1,0 +1,134 @@
+"""Turbovec-backed vector index over `artifacts/` chunks."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+from kryptos.paths import get_artifacts_root, get_turbovec_index_dir
+from kryptos.rag.chunking import iter_artifact_chunks
+from kryptos.rag.embeddings import embed_query, embed_texts
+
+INDEX_NAME = "kryptos-artifacts"
+EMBED_BATCH_SIZE = 64
+BIT_WIDTH = 4
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    score: float
+    path: str
+    chunk_index: int
+    text: str
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class ArtifactIndex:
+    """Turbovec `IdMapIndex` over text chunks from `artifacts/`, with a JSON sidecar
+    mapping vector ids back to their source file/chunk/text."""
+
+    def __init__(self, index_dir: Path | None = None):
+        self._index_dir = index_dir or get_turbovec_index_dir()
+        self._index_path = self._index_dir / f"{INDEX_NAME}.tvim"
+        self._meta_path = self._index_dir / f"{INDEX_NAME}.meta.json"
+        self._index = None
+        self._meta: dict | None = None
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._meta is not None
+
+    def status(self) -> dict:
+        meta = self._meta
+        if meta is None and self._meta_path.exists():
+            meta = json.loads(self._meta_path.read_text(encoding="utf-8"))
+        if meta is None:
+            return {"indexed": False}
+        return {
+            "indexed": True,
+            "chunk_count": len(meta["chunks"]),
+            "model": meta["model"],
+            "built_at": meta["built_at"],
+            "index_path": str(self._index_path),
+        }
+
+    def load(self) -> bool:
+        """Load a previously-built index + sidecar from disk, if present."""
+        if not self._meta_path.exists():
+            return False
+        meta = json.loads(self._meta_path.read_text(encoding="utf-8"))
+        if meta["chunks"] and self._index_path.exists():
+            from turbovec import IdMapIndex
+
+            self._index = IdMapIndex.load(str(self._index_path))
+        else:
+            self._index = None
+        self._meta = meta
+        return True
+
+    def build(self, artifacts_root: Path | None = None) -> dict:
+        """Rebuild the index from scratch over *artifacts_root* (default `artifacts/`)."""
+        artifacts_root = artifacts_root or get_artifacts_root()
+        chunks = list(iter_artifact_chunks(artifacts_root))
+
+        meta: dict = {"model": "", "dim": 0, "built_at": _now(), "chunks": {}}
+        index = None
+
+        if chunks:
+            from turbovec import IdMapIndex
+
+            from kryptos.rag.embeddings import DEFAULT_MODEL_NAME
+
+            vector_batches = []
+            for start in range(0, len(chunks), EMBED_BATCH_SIZE):
+                end = start + EMBED_BATCH_SIZE
+                vector_batches.append(embed_texts([c.text for c in chunks[start:end]]))
+            vectors = np.vstack(vector_batches)
+
+            index = IdMapIndex(dim=vectors.shape[1], bit_width=BIT_WIDTH)
+            ids = np.arange(len(chunks), dtype=np.uint64)
+            index.add_with_ids(vectors, ids)
+
+            meta["model"] = DEFAULT_MODEL_NAME
+            meta["dim"] = int(vectors.shape[1])
+            meta["chunks"] = {str(i): asdict(c) for i, c in enumerate(chunks)}
+
+        self._index_dir.mkdir(parents=True, exist_ok=True)
+        if index is not None:
+            index.write(str(self._index_path))
+        elif self._index_path.exists():
+            self._index_path.unlink()
+        self._meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+        self._index = index
+        self._meta = meta
+        return self.status()
+
+    def search(self, query: str, k: int = 10) -> list[SearchResult]:
+        if self._meta is None:
+            raise RuntimeError("Index not built/loaded. Call build() or load() first.")
+        if self._index is None or not self._meta["chunks"]:
+            return []
+
+        query_vec = embed_query(query, self._meta["model"]).reshape(1, -1)
+        scores, ids = self._index.search(query_vec, k=min(k, len(self._meta["chunks"])))
+
+        results = []
+        for score, chunk_id in zip(scores[0], ids[0], strict=True):
+            chunk_meta = self._meta["chunks"][str(int(chunk_id))]
+            results.append(
+                SearchResult(
+                    score=float(score),
+                    path=chunk_meta["path"],
+                    chunk_index=chunk_meta["chunk_index"],
+                    text=chunk_meta["text"],
+                ),
+            )
+        return results

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -1,0 +1,70 @@
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kryptos import paths
+from kryptos.api.app import create_app
+from kryptos.rag.index import ArtifactIndex
+
+pytestmark = pytest.mark.slow
+
+
+def _write_sample_artifacts(artifacts_root):
+    decisions = artifacts_root / "decisions"
+    decisions.mkdir(parents=True)
+    (decisions / "a.json").write_text(
+        json.dumps({"hypothesis": "Hill cipher 2x2 with key matrix [[5, 10], [13, 1]]"}),
+        encoding="utf-8",
+    )
+
+
+def test_health_endpoint(tmp_path):
+    client = TestClient(create_app(index=ArtifactIndex(index_dir=tmp_path / "index")))
+    assert client.get("/health").json() == {"status": "ok"}
+
+
+def test_rag_search_before_index_returns_409(tmp_path):
+    client = TestClient(create_app(index=ArtifactIndex(index_dir=tmp_path / "index")))
+    resp = client.get("/api/rag/search", params={"q": "foo"})
+    assert resp.status_code == 409
+
+
+def test_rag_status_and_search_with_prebuilt_index(tmp_path):
+    artifacts_root = tmp_path / "artifacts"
+    _write_sample_artifacts(artifacts_root)
+
+    index = ArtifactIndex(index_dir=tmp_path / "index")
+    index.build(artifacts_root=artifacts_root)
+
+    client = TestClient(create_app(index=index))
+
+    status = client.get("/api/rag/status").json()
+    assert status["indexed"] is True
+    assert status["chunk_count"] == 1
+
+    resp = client.get("/api/rag/search", params={"q": "Hill cipher key matrix", "k": 5})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["query"] == "Hill cipher key matrix"
+    assert body["results"][0]["path"] == "decisions/a.json"
+
+
+def test_rag_reindex_endpoint(tmp_path, monkeypatch):
+    artifacts_root = tmp_path / "artifacts"
+    _write_sample_artifacts(artifacts_root)
+
+    monkeypatch.setenv(paths.ENV_ROOT, str(tmp_path))
+    paths.get_repo_root.cache_clear()  # type: ignore[attr-defined]
+    try:
+        index = ArtifactIndex(index_dir=tmp_path / "index")
+        client = TestClient(create_app(index=index))
+
+        resp = client.post("/api/rag/reindex")
+        assert resp.status_code == 200
+        assert resp.json()["chunk_count"] == 1
+
+        status = client.get("/api/rag/status").json()
+        assert status["indexed"] is True
+    finally:
+        paths.get_repo_root.cache_clear()  # type: ignore[attr-defined]

--- a/tests/functional/test_rag_index.py
+++ b/tests/functional/test_rag_index.py
@@ -1,0 +1,67 @@
+import json
+
+import pytest
+
+from kryptos.rag.index import ArtifactIndex
+
+pytestmark = pytest.mark.slow
+
+
+def _write_sample_artifacts(artifacts_root):
+    decisions = artifacts_root / "decisions"
+    decisions.mkdir(parents=True)
+    (decisions / "a.json").write_text(
+        json.dumps({"hypothesis": "Hill cipher 2x2 with key matrix [[5, 10], [13, 1]]"}),
+        encoding="utf-8",
+    )
+    (artifacts_root / "notes.md").write_text(
+        "# Notes\nBerlin Clock lamp counts as transposition column widths.",
+        encoding="utf-8",
+    )
+
+
+def test_status_before_build(tmp_path):
+    index = ArtifactIndex(index_dir=tmp_path / "index")
+    assert index.status() == {"indexed": False}
+
+
+def test_build_and_search(tmp_path):
+    artifacts_root = tmp_path / "artifacts"
+    _write_sample_artifacts(artifacts_root)
+
+    index = ArtifactIndex(index_dir=tmp_path / "index")
+    status = index.build(artifacts_root=artifacts_root)
+
+    assert status["indexed"] is True
+    assert status["chunk_count"] == 2
+
+    results = index.search("Hill cipher key matrix", k=1)
+    assert len(results) == 1
+    assert results[0].path == "decisions/a.json"
+
+
+def test_load_round_trip(tmp_path):
+    artifacts_root = tmp_path / "artifacts"
+    _write_sample_artifacts(artifacts_root)
+
+    index_dir = tmp_path / "index"
+    ArtifactIndex(index_dir=index_dir).build(artifacts_root=artifacts_root)
+
+    reloaded = ArtifactIndex(index_dir=index_dir)
+    assert reloaded.load() is True
+    assert reloaded.status()["chunk_count"] == 2
+
+    results = reloaded.search("Berlin Clock transposition", k=1)
+    assert results[0].path == "notes.md"
+
+
+def test_build_empty_artifacts(tmp_path):
+    artifacts_root = tmp_path / "artifacts"
+    artifacts_root.mkdir()
+
+    index = ArtifactIndex(index_dir=tmp_path / "index")
+    status = index.build(artifacts_root=artifacts_root)
+
+    assert status["indexed"] is True
+    assert status["chunk_count"] == 0
+    assert index.search("anything", k=5) == []


### PR DESCRIPTION
## Summary
- Adds `kryptos serve`, a minimal FastAPI app (`src/kryptos/api/`) exposing `/health`, `/api/rag/status`, `POST /api/rag/reindex`, and `GET /api/rag/search`
- Adds `src/kryptos/rag/`: chunks `artifacts/` (`.json`/`.md`), embeds chunks with `sentence-transformers` (`all-MiniLM-L6-v2`), and indexes them with a 4-bit quantized `turbovec.IdMapIndex` persisted under `data/turbovec/`
- New `kryptos.paths.get_data_root()` / `get_turbovec_index_dir()` helpers, following the existing `paths.py` pattern
- This is the "Now" item #1 from agent-board's `docs/AI_STACK_STRATEGY.md`: cipher/hypothesis RAG over `artifacts/`, pure `pip install`, no infra overhaul

Includes one drive-by fix needed to unblock pre-commit on `src/kryptos/cli/main.py`: the `black` hook had no `--line-length` arg (default 88) while `isort`/`flake8` target 120, causing black/isort to oscillate on any touched file. Pinned black to 120 in a separate commit.

## Test plan
- [x] `pytest tests/functional/test_rag_index.py tests/functional/test_api.py -m slow` — 8/8 pass (new tests, real `sentence-transformers` + `turbovec`)
- [x] `pytest tests/functional/test_paths_helpers.py tests/smoke/test_cli.py tests/smoke/test_cli_subcommands.py` — 16/16 pass
- [x] Full fast suite via Docker (`pytest -m "not slow"`): 896 passed, 16 skipped, 10 deselected, 92.35% coverage
- [x] Manual: `uvicorn kryptos.api.app:app` + curl `/health`, `/api/rag/status`, `POST /api/rag/reindex`, `/api/rag/search`
- [x] All pre-commit hooks pass (black, isort, flake8, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)