### PR TITLE
Stress tests for K1/K2 Vigenere key recovery

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Next Review: 2026-07-01
 
 ### Phase 4 — Validation & hardening
 - [x] **K3 double-transposition Monte Carlo** — `kryptos.k3.double_rotation_solver` generalizes K3's two-stage 90cw rotation to all divisor-width/rotation-type pairs; brute-force solver exactly recovers K3's plaintext as the top candidate. Monte Carlo across random parameter pairs: 75% best-of-top-10 success (`tests/e2e/test_k3_double_rotation_monte_carlo.py`)
-- [ ] **Stress tests for K1/K2** — test with noise, wrong key lengths, partial ciphertext
+- [x] **Stress tests for K1/K2** — `kryptos.k4.vigenere_stress_tests.run_k1_k2_stress_suite` exercises noise injection, wrong key lengths, and partial-ciphertext truncation against `recover_key_by_frequency`. K2 (367-char ciphertext) recovers ABSCISSA at noise up to 20% (8/8 trials) and truncation down to 25% (4/4 trials); K1 (63-char ciphertext) only survives noise up to 5% (4/8 trials) and requires the full ciphertext (1/4 partial trials). Wrong key length always fails for both (`tests/e2e/test_k1_k2_stress_suite.py`)
 
 ### Phase 5 — Post-solution
 - [ ] **Solution documentation** — once K4 is solved: full attack path, key insights, solution narrative

--- a/TASKS.md
+++ b/TASKS.md
@@ -45,3 +45,10 @@ Last Updated: 2026-06-10
 - [x] **Generalized double-rotation solver** — `kryptos.k3.double_rotation_solver` generalizes K3's two-stage 90cw grid rotation to all 18 divisor-widths of 336 x 6 rotation types, both stages. `apply_double_rotation(K3_CIPHERTEXT, 24, '90cw', 8, '90cw') == K3_PLAINTEXT` confirmed exactly.
 - [x] **Brute-force recovery** — `brute_force_double_rotation_solve` ranks K3's true plaintext as the #1 candidate (match_ratio=1.0) out of 11,664 (width, rotation) combinations.
 - [x] **Monte Carlo validation** — `run_k3_double_rotation_monte_carlo` over 20 random parameter pairs: 75% best-of-top-10 success. Failures cluster around `'identity'`/extreme-aspect-ratio grids whose score-tied cyclic rearrangements of the plaintext outrank the exact match under n-gram/word scoring (see `tests/e2e/test_k3_double_rotation_monte_carlo.py`).
+
+### K1/K2 Vigenère Stress Tests (Phase 4 validation)
+
+- [x] **Stress-test harness** — `kryptos.k4.vigenere_stress_tests.run_k1_k2_stress_suite` runs `recover_key_by_frequency` against K1 (PALIMPSEST, 63-char ciphertext) and K2 (ABSCISSA, 367-char ciphertext) across noise injection (0/5/10/20%, 2 trials each), wrong key lengths (+/-2 around the true length), and partial-ciphertext truncation (100/75/50/25%).
+- [x] **Noise**: K2 recovers ABSCISSA at all 8 trials up to 20% noise (plaintext match ratio degrades gracefully 1.0 -> ~0.76); K1 only recovers PALIMPSEST at 0% and 5% noise (4/8 trials), collapsing to wrong keys at 10%/20%.
+- [x] **Wrong key length**: for both K1 and K2, only the true key length yields the correct key with a perfect plaintext match; all four off-by-(-2..+2) lengths fail for both.
+- [x] **Partial ciphertext**: K2 recovers ABSCISSA exactly down to 25% (91 chars); K1 only recovers PALIMPSEST at 100% (63 chars) -- 75/50/25% truncations all fail. See `tests/e2e/test_k1_k2_stress_suite.py` and `docs/analysis/K1_K2_VALIDATION_RESULTS.md`.

--- a/docs/analysis/K1_K2_VALIDATION_RESULTS.md
+++ b/docs/analysis/K1_K2_VALIDATION_RESULTS.md
@@ -232,17 +232,77 @@ Update README or docs with:
 
 ### 5. Consider Stress Testing
 
-Future tests to add:
-- K1/K2 with noise (corrupted ciphertext)
-- K1/K2 with wrong key lengths
-- K1/K2 with partial ciphertext
-- K1/K2 with mixed case or punctuation
+**Status: DONE (see 2026-06-10 update below)** — noise, wrong key lengths, and
+partial ciphertext are now covered by `kryptos.k4.vigenere_stress_tests`.
+Mixed case/punctuation is not applicable: the ciphertexts are always
+normalized to uppercase A-Z before recovery (`recover_key_by_frequency`
+groups by alphabetic character only), so case/punctuation variants would
+exercise the same code path as the existing tests.
+
+---
+
+## 2026-06-10 Update: Stress Testing (Noise, Wrong Key Length, Partial Ciphertext)
+
+`kryptos.k4.vigenere_stress_tests.run_k1_k2_stress_suite` runs
+`recover_key_by_frequency` against K1 (PALIMPSEST, 63-char ciphertext) and K2
+(ABSCISSA, 367-char ciphertext) across the three dimensions flagged above as
+untested. All results below are deterministic with `seed=42`
+(`tests/e2e/test_k1_k2_stress_suite.py`, `artifacts/k1_k2_stress_tests.json`).
+
+**Noise** (random A-Z substitutions at each rate, 2 trials/rate):
+
+| Noise rate | K1 key recovered | K2 key recovered |
+|---|---|---|
+| 0% | PALIMPSEST x2 (ratio 1.0) | ABSCISSA x2 (ratio 1.0) |
+| 5% | PALIMPSEST x2 (ratio ~0.98-1.0) | ABSCISSA x2 (ratio ~0.95-0.96) |
+| 10% | wrong key x2 (ratio ~0.21-0.33) | ABSCISSA x2 (ratio ~0.89-0.91) |
+| 20% | wrong key x2 (ratio ~0.29-0.37) | ABSCISSA x2 (ratio ~0.76-0.81) |
+
+K2's longer ciphertext provides enough statistical signal to recover ABSCISSA
+correctly at every noise level tested (8/8), with plaintext match ratio
+degrading gracefully as noise increases. K1's much shorter ciphertext is
+fragile: only the 0% and 5% trials (4/8 total) recover PALIMPSEST; at 10%/20%
+noise the algorithm converges on a different key entirely and the resulting
+plaintext is mostly wrong.
+
+**Wrong key length** (offsets -2..+2 around the true length, top_n=5):
+
+For both K1 (lengths 8-12) and K2 (lengths 6-10), only the true key length
+(10 and 8 respectively) returns the correct key with `plaintext_match_ratio
+== 1.0`. All four incorrect lengths fail for both ciphers -- the correct key
+never appears in the top-5 candidates, and the resulting plaintexts are
+near-random (~3-17% match ratio). This confirms `recover_key_by_frequency`
+cannot bootstrap an unknown key length from frequency analysis alone; it
+requires the key length as an input (e.g. from Kasiski/IC analysis).
+
+**Partial ciphertext** (truncated to 100/75/50/25% of length, key length fixed
+at the true value):
+
+| Fraction | K1 (63 chars) | K2 (367 chars) |
+|---|---|---|
+| 100% | PALIMPSEST (1.0) | ABSCISSA (1.0) |
+| 75% | wrong key (0.43) | ABSCISSA (1.0) |
+| 50% | wrong key (0.29) | ABSCISSA (1.0) |
+| 25% | wrong key (0.33) | ABSCISSA (1.0) |
+
+K2 recovers ABSCISSA exactly even at 25% (91 chars). K1 requires its full 63
+characters -- any truncation drops recovery to a wrong key.
+
+**Takeaway:** the K1/K2 100% Monte Carlo success rates documented above hold
+for *clean, full-length ciphertext at the correct key length*. Robustness to
+noise and truncation scales with ciphertext length: K2 (367 chars) is highly
+robust, K1 (63 chars) is not. Wrong key length is not recoverable by this
+algorithm regardless of ciphertext length -- it is a precondition, not a
+robustness dimension.
 
 ---
 
 ## Files
 
 - **Test file:** `tests/test_k1_k2_monte_carlo.py`
+- **Stress-test harness:** `src/kryptos/k4/vigenere_stress_tests.py`
+- **Stress-test files:** `tests/functional/test_k1_k2_vigenere_stress.py`, `tests/e2e/test_k1_k2_stress_suite.py`
+- **Stress-test results:** `artifacts/k1_k2_stress_tests.json`
 - **Results doc:** `K1_K2_VALIDATION_RESULTS.md` (this file)
 - **Related:** `K3_VALIDATION_RESULTS.md`
 - **Test output:** See pytest run logs

--- a/src/kryptos/k4/vigenere_stress_tests.py
+++ b/src/kryptos/k4/vigenere_stress_tests.py
@@ -1,0 +1,221 @@
+"""Stress-testing harness for K1/K2 Vigenère key recovery.
+
+``kryptos.k4.vigenere_key_recovery.recover_key_by_frequency`` has only been
+validated on clean K1/K2 ciphertext at the correct key length
+(``docs/analysis/K1_K2_VALIDATION_RESULTS.md``: deterministic 100% recovery
+for both PALIMPSEST and ABSCISSA). This is the "Stress tests for K1/K2" item
+from ROADMAP.md (Phase 4: Validation & hardening), covering the three
+dimensions that document explicitly flagged as untested:
+
+- **Noise**: random single-character substitutions in the ciphertext.
+- **Wrong key length**: recovery attempted at lengths other than the true key length.
+- **Partial ciphertext**: recovery attempted on a truncated prefix of the ciphertext.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from kryptos.ciphers import vigenere_decrypt
+from kryptos.k4.vigenere_key_recovery import recover_key_by_frequency
+
+ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+# Verified K1 ciphertext/plaintext (tests/smoke/test_k1_k2_k3_reliability.py)
+K1_CIPHERTEXT = "EMUFPHZLRFAXYUSDJKZLDKRNSHGNFIVJYQTQUXQBQVYUVLLTREVJYQTMKYRDMFD"
+K1_KEY = "PALIMPSEST"
+K1_PLAINTEXT = "BETWEENSUBTLESHADINGANDTHEABSENCEOFLIGHTLIESTHENUANCEOFIQLUSION"
+
+# K2 ciphertext (tests/smoke/test_k1_k2_k3_reliability.py); plaintext derived by
+# decrypting with the known key ABSCISSA, used here as the ground truth that
+# recover_key_by_frequency is expected to reproduce under stress.
+K2_CIPHERTEXT = (
+    "VFPJUDEEHZWETZYVGWHKKQETGFQJNCEGGWHKKDQMCPFQZDQMMIAGPFXHQRLGTIM"
+    "VMZJANQLVKQEDAGDVFRPJUNGEUNAQZGZLECGYUXUEENJTBJLBQCRTBJDFHRRYIZE"
+    "TKZEMVDUFKSJHKFWHKUWQLSZFTIHHDDDUVHDWKBFUFPWNTDFIYCUQZEREEVLDKFE"
+    "ZMOQQJLTTUGSYQPFEUNLAVIDXFLGGTEZFKZBSFDQVGOGIPUFXHHDRKFFHQNTGPUA"
+    "ECNUVPDJMQCLQUMUNEDFQELZZVRRGKFFVOEEXBDMVPNFQXEZLGREDNQFCHOBSSPH"
+    "FLLOXQRZXGZQAAVTTEXOLIQQTIVWHHMQAUQZMASMRVLQJNWB"
+)
+K2_KEY = "ABSCISSA"
+K2_PLAINTEXT = vigenere_decrypt(K2_CIPHERTEXT, K2_KEY)
+
+
+def inject_noise(ciphertext: str, noise_rate: float, rng: random.Random) -> str:
+    """Replace each alphabetic character with a uniformly random A-Z letter with probability ``noise_rate``."""
+    return "".join(rng.choice(ALPHABET) if ch.isalpha() and rng.random() < noise_rate else ch for ch in ciphertext)
+
+
+def _match_ratio(a: str, b: str) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    return sum(1 for x, y in zip(a, b, strict=True) if x == y) / len(a)
+
+
+@dataclass(frozen=True)
+class NoiseStressRun:
+    noise_rate: float
+    trial: int
+    recovered_key: str | None
+    key_match: bool
+    plaintext_match_ratio: float
+
+
+def run_noise_stress_test(
+    ciphertext: str,
+    key: str,
+    plaintext: str,
+    noise_rates: tuple[float, ...] = (0.0, 0.05, 0.10, 0.20),
+    trials_per_rate: int = 2,
+    seed: int = 42,
+    top_n: int = 5,
+) -> list[NoiseStressRun]:
+    """Inject random-character noise at increasing rates and check whether key recovery survives."""
+    rng = random.Random(seed)
+    runs = []
+    for noise_rate in noise_rates:
+        for trial in range(trials_per_rate):
+            noisy = inject_noise(ciphertext, noise_rate, rng)
+            candidates = recover_key_by_frequency(noisy, key_length=len(key), top_n=top_n)
+            recovered_key = candidates[0] if candidates else None
+            decrypted = vigenere_decrypt(noisy, recovered_key) if recovered_key else ""
+            runs.append(
+                NoiseStressRun(
+                    noise_rate=noise_rate,
+                    trial=trial,
+                    recovered_key=recovered_key,
+                    key_match=recovered_key == key,
+                    plaintext_match_ratio=_match_ratio(decrypted, plaintext),
+                )
+            )
+    return runs
+
+
+@dataclass(frozen=True)
+class KeyLengthStressRun:
+    key_length: int
+    is_correct_length: bool
+    top_candidate: str | None
+    correct_key_in_top: bool
+    plaintext_match_ratio: float
+
+
+def run_key_length_stress_test(
+    ciphertext: str,
+    key: str,
+    plaintext: str,
+    candidate_lengths: tuple[int, ...],
+    top_n: int = 5,
+) -> list[KeyLengthStressRun]:
+    """Run key recovery at a range of key lengths, most of them deliberately wrong."""
+    runs = []
+    for kl in candidate_lengths:
+        candidates = recover_key_by_frequency(ciphertext, key_length=kl, top_n=top_n)
+        top_candidate = candidates[0] if candidates else None
+        decrypted = vigenere_decrypt(ciphertext, top_candidate) if top_candidate else ""
+        runs.append(
+            KeyLengthStressRun(
+                key_length=kl,
+                is_correct_length=(kl == len(key)),
+                top_candidate=top_candidate,
+                correct_key_in_top=key in candidates,
+                plaintext_match_ratio=_match_ratio(decrypted, plaintext),
+            )
+        )
+    return runs
+
+
+@dataclass(frozen=True)
+class PartialCiphertextStressRun:
+    fraction: float
+    ciphertext_length: int
+    recovered_key: str | None
+    key_match: bool
+    plaintext_match_ratio: float
+
+
+def run_partial_ciphertext_stress_test(
+    ciphertext: str,
+    key: str,
+    plaintext: str,
+    fractions: tuple[float, ...] = (1.0, 0.75, 0.5, 0.25),
+    top_n: int = 5,
+) -> list[PartialCiphertextStressRun]:
+    """Truncate the ciphertext to decreasing fractions and check whether key recovery survives."""
+    runs = []
+    for fraction in fractions:
+        n = max(len(key), int(len(ciphertext) * fraction))
+        partial = ciphertext[:n]
+        candidates = recover_key_by_frequency(partial, key_length=len(key), top_n=top_n)
+        recovered_key = candidates[0] if candidates else None
+        decrypted = vigenere_decrypt(partial, recovered_key) if recovered_key else ""
+        runs.append(
+            PartialCiphertextStressRun(
+                fraction=fraction,
+                ciphertext_length=n,
+                recovered_key=recovered_key,
+                key_match=recovered_key == key,
+                plaintext_match_ratio=_match_ratio(decrypted, plaintext[:n]),
+            )
+        )
+    return runs
+
+
+def run_k1_k2_stress_suite(
+    noise_rates: tuple[float, ...] = (0.0, 0.05, 0.10, 0.20),
+    noise_trials_per_rate: int = 2,
+    key_length_offsets: tuple[int, ...] = (-2, -1, 0, 1, 2),
+    partial_fractions: tuple[float, ...] = (1.0, 0.75, 0.5, 0.25),
+    seed: int = 42,
+    top_n: int = 5,
+    results_path: Path | str | None = None,
+) -> dict:
+    """Run noise / wrong-key-length / partial-ciphertext stress tests for both K1 and K2."""
+    sections = {}
+    for label, ciphertext, key, plaintext in (
+        ("K1", K1_CIPHERTEXT, K1_KEY, K1_PLAINTEXT),
+        ("K2", K2_CIPHERTEXT, K2_KEY, K2_PLAINTEXT),
+    ):
+        candidate_lengths = tuple(
+            sorted({len(key) + offset for offset in key_length_offsets if len(key) + offset >= 2})
+        )
+        sections[label] = {
+            "noise": [
+                asdict(r)
+                for r in run_noise_stress_test(
+                    ciphertext, key, plaintext, noise_rates, noise_trials_per_rate, seed, top_n
+                )
+            ],
+            "key_length": [
+                asdict(r) for r in run_key_length_stress_test(ciphertext, key, plaintext, candidate_lengths, top_n)
+            ],
+            "partial_ciphertext": [
+                asdict(r)
+                for r in run_partial_ciphertext_stress_test(ciphertext, key, plaintext, partial_fractions, top_n)
+            ],
+        }
+
+    summary = {
+        "attack": "k1_k2_stress_tests",
+        "run_params": {
+            "noise_rates": list(noise_rates),
+            "noise_trials_per_rate": noise_trials_per_rate,
+            "key_length_offsets": list(key_length_offsets),
+            "partial_fractions": list(partial_fractions),
+            "seed": seed,
+            "top_n": top_n,
+        },
+        "results": sections,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    if results_path is not None:
+        path = Path(results_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(summary, indent=2))
+
+    return summary

--- a/tests/e2e/test_k1_k2_stress_suite.py
+++ b/tests/e2e/test_k1_k2_stress_suite.py
@@ -1,0 +1,74 @@
+"""K1/K2 Vigenère key-recovery stress suite (Phase 4: Validation & hardening).
+
+Runs `kryptos.k4.vigenere_stress_tests.run_k1_k2_stress_suite` across the three
+dimensions flagged as untested in `docs/analysis/K1_K2_VALIDATION_RESULTS.md`
+("Consider Stress Testing"): noise, wrong key length, and partial ciphertext.
+
+Each `recover_key_by_frequency` call costs ~5-7s regardless of input size (the
+500k-candidate heap cap dominates), and the full suite makes 34 such calls
+(16 noise + 10 key-length + 8 partial across K1+K2), so this is gated behind
+KRYPTOS_RUN_SLOW_MONTE_CARLO like the other Monte Carlo e2e tests.
+"""
+
+import os
+
+import pytest
+
+from kryptos.k4.vigenere_stress_tests import K1_KEY, K2_KEY, run_k1_k2_stress_suite
+
+if os.getenv("KRYPTOS_RUN_SLOW_MONTE_CARLO") != "1":
+    pytest.skip(
+        "Set KRYPTOS_RUN_SLOW_MONTE_CARLO=1 to run this slow module",
+        allow_module_level=True,
+    )
+
+
+@pytest.mark.slow
+def test_k1_k2_stress_suite():
+    """Empirical results with seed=42 (`artifacts/k1_k2_stress_tests.json`):
+
+    - **Noise**: K2 (367-char ciphertext) recovers ABSCISSA at all 8 trials
+      (noise rates 0.0/0.05/0.10/0.20), with plaintext match ratio degrading
+      gracefully from 1.0 to ~0.76 as noise increases. K1 (63-char ciphertext)
+      only recovers PALIMPSEST at noise rates 0.0 and 0.05 (4/8 trials);
+      at 10%/20% noise the recovered key is wrong and plaintext match ratio
+      collapses to ~0.2-0.37.
+    - **Wrong key length**: for both K1 and K2, only the true key length
+      yields the correct key in the top-N candidates with a perfect
+      plaintext match; all four off-by-(-2..+2) lengths fail for both.
+    - **Partial ciphertext**: K2 recovers ABSCISSA exactly down to 25%
+      (91 chars) of its ciphertext. K1 only recovers PALIMPSEST at 100%
+      (63 chars); 75%/50%/25% truncations all fail.
+    """
+    summary = run_k1_k2_stress_suite(results_path="artifacts/k1_k2_stress_tests.json")
+    k1 = summary["results"]["K1"]
+    k2 = summary["results"]["K2"]
+
+    # --- Sanity baseline: zero noise / full ciphertext always recovers the true key ---
+    for section in (k1, k2):
+        zero_noise_runs = [r for r in section["noise"] if r["noise_rate"] == 0.0]
+        assert all(r["key_match"] and r["plaintext_match_ratio"] == 1.0 for r in zero_noise_runs)
+
+        full_partial = next(r for r in section["partial_ciphertext"] if r["fraction"] == 1.0)
+        assert full_partial["key_match"] and full_partial["plaintext_match_ratio"] == 1.0
+
+    # --- Wrong key length: correct length always succeeds, all others always fail ---
+    for section, key in ((k1, K1_KEY), (k2, K2_KEY)):
+        for run in section["key_length"]:
+            if run["key_length"] == len(key):
+                assert run["correct_key_in_top"] and run["plaintext_match_ratio"] == 1.0
+            else:
+                assert not run["correct_key_in_top"]
+
+    # --- K2: long ciphertext gives enough signal to survive noise and truncation ---
+    assert all(r["key_match"] for r in k2["noise"])
+    assert all(r["key_match"] and r["plaintext_match_ratio"] == 1.0 for r in k2["partial_ciphertext"])
+
+    # --- K1: short ciphertext is fragile -- only low noise / full length recover the key ---
+    k1_noise_success = sum(1 for r in k1["noise"] if r["key_match"])
+    assert k1_noise_success == 4
+    assert all(r["key_match"] for r in k1["noise"] if r["noise_rate"] <= 0.05)
+    assert not any(r["key_match"] for r in k1["noise"] if r["noise_rate"] >= 0.10)
+
+    k1_partial_success = [r["fraction"] for r in k1["partial_ciphertext"] if r["key_match"]]
+    assert k1_partial_success == [1.0]

--- a/tests/functional/test_k1_k2_vigenere_stress.py
+++ b/tests/functional/test_k1_k2_vigenere_stress.py
@@ -1,0 +1,59 @@
+"""Functional tests for kryptos.k4.vigenere_stress_tests utilities.
+
+Covers the pure helper functions (noise injection, match-ratio scoring) and
+the K1/K2 constants. The expensive recover_key_by_frequency-based stress
+runs are exercised in tests/e2e/test_k1_k2_stress_suite.py.
+"""
+
+from __future__ import annotations
+
+import random
+
+from kryptos.ciphers import vigenere_decrypt
+from kryptos.k4.vigenere_stress_tests import (
+    K1_CIPHERTEXT,
+    K1_KEY,
+    K1_PLAINTEXT,
+    K2_CIPHERTEXT,
+    K2_KEY,
+    K2_PLAINTEXT,
+    _match_ratio,
+    inject_noise,
+)
+
+
+def test_constants_round_trip():
+    assert vigenere_decrypt(K1_CIPHERTEXT, K1_KEY) == K1_PLAINTEXT
+    assert vigenere_decrypt(K2_CIPHERTEXT, K2_KEY) == K2_PLAINTEXT
+    assert len(K1_CIPHERTEXT) == len(K1_PLAINTEXT)
+    assert len(K2_CIPHERTEXT) == len(K2_PLAINTEXT)
+
+
+def test_inject_noise_zero_rate_is_identity():
+    rng = random.Random(0)
+    assert inject_noise(K1_CIPHERTEXT, 0.0, rng) == K1_CIPHERTEXT
+
+
+def test_inject_noise_full_rate_only_touches_alpha_chars():
+    text = "AB12 CD"
+    rng = random.Random(0)
+    noisy = inject_noise(text, 1.0, rng)
+    assert len(noisy) == len(text)
+    for original, replaced in zip(text, noisy, strict=True):
+        if original.isalpha():
+            assert replaced.isalpha()
+        else:
+            assert replaced == original
+
+
+def test_match_ratio_identical():
+    assert _match_ratio("ABCDEF", "ABCDEF") == 1.0
+
+
+def test_match_ratio_partial():
+    assert _match_ratio("ABCD", "ABXY") == 0.5
+
+
+def test_match_ratio_length_mismatch_or_empty():
+    assert _match_ratio("ABC", "AB") == 0.0
+    assert _match_ratio("", "") == 0.0


### PR DESCRIPTION
## Summary
- Implements the "Stress tests for K1/K2" item from ROADMAP.md (Phase 4: Validation & hardening)
- Adds `kryptos.k4.vigenere_stress_tests` with `run_k1_k2_stress_suite`, exercising `recover_key_by_frequency` against K1 (PALIMPSEST, 63-char ciphertext) and K2 (ABSCISSA, 367-char ciphertext) under noise injection, wrong key lengths, and partial-ciphertext truncation
- Functional tests (`tests/functional/test_k1_k2_vigenere_stress.py`) cover the pure helpers (noise injection, match-ratio scoring, constants round-trip)
- E2e Monte Carlo-style test (`tests/e2e/test_k1_k2_stress_suite.py`, gated by `KRYPTOS_RUN_SLOW_MONTE_CARLO=1`, `@pytest.mark.slow`) asserts the empirical seed=42 results and writes `artifacts/k1_k2_stress_tests.json`

## Findings
- **Noise**: K2 (longer ciphertext) recovers ABSCISSA at all 8 trials up to 20% noise; K1 (shorter ciphertext) only recovers PALIMPSEST at 0%/5% noise (4/8 trials)
- **Wrong key length**: always fails for both K1 and K2 -- frequency analysis depends on correct column grouping
- **Partial ciphertext**: K2 recovers ABSCISSA exactly down to 25% (91 chars); K1 requires its full 63 characters

Docs updated: `ROADMAP.md`, `TASKS.md`, `docs/analysis/K1_K2_VALIDATION_RESULTS.md` (new "2026-06-10 Update" section).

## Test plan
- [x] `pytest tests/functional/test_k1_k2_vigenere_stress.py -m 'not slow'` -- 6 passed
- [x] `pytest tests/e2e/test_k1_k2_stress_suite.py -m slow` (with `KRYPTOS_RUN_SLOW_MONTE_CARLO=1`) -- 1 passed in 189s
- [x] black / isort / flake8 / mypy clean on new files
- [x] pre-commit hooks pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)