### PR TITLE
feat(pipeline): wire LinguistAgent into validator stage 3 (opt-in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ MANIFEST
 /data/*.generated
 # turbovec RAG index, generated from gitignored artifacts/
 /data/turbovec/
+# LINGUIST agent model cache (downloaded on first use when enable_linguist=True)
+/data/linguist/
 reports/
 artifacts/
 /agents/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,11 +64,13 @@ Next Review: 2026-07-01
 > `ops_director` (API drift masked by tests mocking buggy call-site signatures),
 > including a crash-on-startup (`SpyNLP()` requiring `en_core_web_sm`, not present
 > in the runtime image) and a crash-on-cycle-1 (`analyze_situation()` returning
-> `None` was unhandled). `linguist.py` is confirmed standalone/well-tested but not
-> wired into the main pipeline; documented as a future integration candidate. A
-> 5th bug — `run_autonomous_loop(max_hours=0.0, ...)` looping forever due to a
-> falsy-zero check, previously masked by the crash-on-cycle-1 bug — was uncovered
-> by a 6-hour CI hang after the cycle-1 crash was fixed, and also fixed. See
+> `None` was unhandled). `linguist.py` is confirmed standalone/well-tested and was
+> subsequently wired into `pipeline/validator.py` stage 3 as an opt-in enhanced-
+> scoring pass (`PlaintextValidator(enable_linguist=True)`, default `False`,
+> degrades gracefully without `torch`/`transformers`). A 5th bug —
+> `run_autonomous_loop(max_hours=0.0, ...)` looping forever due to a falsy-zero
+> check, previously masked by the crash-on-cycle-1 bug — was uncovered by a 6-hour
+> CI hang after the cycle-1 crash was fixed, and also fixed. See
 > `docs/analysis/AGENT_MODULE_REVIEW.md`.
 
 ---

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,11 +1,9 @@
 # Tasks
 
-Last Updated: 2026-06-10
+Last Updated: 2026-06-11
 
 
 ## Todo
-
-- [ ] **Linguist integration** — wire `LinguistAgent.cross_validate_with_spy`/`batch_validate` (`kryptos.agents.linguist`) into `pipeline/validator.py` stage 3 as an optional enhanced-scoring pass alongside `scoring_enhanced`, gated on `torch`/`transformers` availability (see `docs/analysis/AGENT_MODULE_REVIEW.md`).
 
 # Q1 2027: Final Push & Post-Solution Analysis
 
@@ -44,6 +42,10 @@ Last Updated: 2026-06-10
 - [x] **Bug 5 — `run_autonomous_loop(max_hours=0.0, ...)` infinite loop** — `if max_hours and ...` / `if max_cycles and ...` treated `0`/`0.0` ("exit immediately") the same as `None` ("infinite"), since both are falsy. Previously masked by Bug 4's crash-based early exit; exposed once Bug 4 was fixed, causing PR CI to hang for the full 6-hour job timeout (twice). Fixed via `is not None` checks; verified the previously-hanging test now passes in 15.29s.
 - [x] **`linguist.py` status** — confirmed standalone, extensively unit-tested (`tests/functional/test_linguist.py`), not wired into `pipeline/validator.py` (which uses `scoring_enhanced` instead). Documented as a future integration candidate (see Todo).
 - [x] **Updated `docs/reference/AGENTS_ARCHITECTURE.md`, `ROADMAP.md`** with corrected integration details and findings summary.
+
+### Linguist Integration (`pipeline/validator.py` stage 3)
+
+- [x] **Wired `LinguistAgent` into `PlaintextValidator`** — new `enable_linguist` constructor flag (default `False`). `_init_linguist()` gates on `torch`/`transformers` availability and `LinguistAgent` construction, degrading to `linguist_available=False` on any failure. When enabled, `stage3_linguistic_validation()` adds a `"linguist"` key (confidence/perplexity/coherence/grammar_score/model_used/passed) alongside the existing heuristic fields; `_linguist_score()` and the new `batch_validate_linguist()` re-ranking helper both catch and log scoring exceptions, returning `None` rather than raising. Existing default (`enable_linguist=False`) behavior and `"linguist"`-key absence are unchanged. See `tests/functional/test_validator_linguist.py`.
 
 ### RAG API (turbovec) — semantic search over `artifacts/`
 

--- a/docs/reference/AGENTS_ARCHITECTURE.md
+++ b/docs/reference/AGENTS_ARCHITECTURE.md
@@ -46,7 +46,7 @@ Corpus-style linguistic scoring using Sanborn's known plaintext as reference mat
 
 | Module | Role |
 |--------|------|
-| `agents/linguist.py` | `LinguistAgent`, `LinguisticScore`, `SanbornCorpusAnalysis`. **Standalone** — not currently wired into `AutonomousCoordinator` or `pipeline/validator.py`. The main pipeline's stage-3 linguistic validation uses `scoring_enhanced.combined_linguistic_score`/`linguistic_diagnostics` instead. `LinguistAgent` offers richer (transformer-based, with heuristic fallback) perplexity/coherence scoring; see `docs/analysis/AGENT_MODULE_REVIEW.md` for a possible future integration path. |
+| `agents/linguist.py` | `LinguistAgent`, `LinguisticScore`, `SanbornCorpusAnalysis`. Optional enhanced-scoring pass wired into `pipeline/validator.py` stage 3 via `PlaintextValidator(enable_linguist=True)` (default `False`). When enabled, `_init_linguist()` requires `torch`/`transformers`; if unavailable or initialization fails, degrades gracefully to `linguist_available=False` and stage 3 behaves exactly as before. `LinguistAgent` offers transformer-based (with heuristic fallback) perplexity/coherence scoring via `validate_candidate`/`batch_validate`, exposed as `PlaintextValidator._linguist_score`/`batch_validate_linguist`. |
 
 ### K123 Analyzer — pattern extraction from solved sections
 
@@ -116,6 +116,7 @@ Strategy knowledge (`strategy_kb` table) is read by `OpsStrategicDirector` on in
 | `tests/functional/test_ops_agent.py` | OPS strategic decisions |
 | `tests/functional/test_q_agent.py` | Q validation thresholds |
 | `tests/functional/test_linguist.py` | Linguist scoring |
+| `tests/functional/test_validator_linguist.py` | LINGUIST integration in `pipeline/validator.py` stage 3 (opt-in, graceful degradation) |
 | `tests/functional/test_spy_*.py` | SPY pattern analysis |
 | `tests/smoke/test_cli_subcommands.py` | CLI entry points |
 

--- a/src/kryptos/pipeline/validator.py
+++ b/src/kryptos/pipeline/validator.py
@@ -18,32 +18,32 @@ from typing import Any
 from kryptos.log_setup import setup_logging
 
 ENGLISH_FREQ = {
-    'E': 12.70,
-    'T': 9.06,
-    'A': 8.17,
-    'O': 7.51,
-    'I': 6.97,
-    'N': 6.75,
-    'S': 6.33,
-    'H': 6.09,
-    'R': 5.99,
-    'D': 4.25,
-    'L': 4.03,
-    'C': 2.78,
-    'U': 2.76,
-    'M': 2.41,
-    'W': 2.36,
-    'F': 2.23,
-    'G': 2.02,
-    'Y': 1.97,
-    'P': 1.93,
-    'B': 1.29,
-    'V': 0.98,
-    'K': 0.77,
-    'J': 0.15,
-    'X': 0.15,
-    'Q': 0.10,
-    'Z': 0.07,
+    "E": 12.70,
+    "T": 9.06,
+    "A": 8.17,
+    "O": 7.51,
+    "I": 6.97,
+    "N": 6.75,
+    "S": 6.33,
+    "H": 6.09,
+    "R": 5.99,
+    "D": 4.25,
+    "L": 4.03,
+    "C": 2.78,
+    "U": 2.76,
+    "M": 2.41,
+    "W": 2.36,
+    "F": 2.23,
+    "G": 2.02,
+    "Y": 1.97,
+    "P": 1.93,
+    "B": 1.29,
+    "V": 0.98,
+    "K": 0.77,
+    "J": 0.15,
+    "X": 0.15,
+    "Q": 0.10,
+    "Z": 0.07,
 }
 
 
@@ -55,7 +55,7 @@ def simple_dictionary_score(text: str) -> float:
     if not normalized:
         return 0.0
 
-    freq = {}
+    freq: dict[str, float] = {}
     for c in normalized:
         freq[c] = freq.get(c, 0) + 1
 
@@ -96,6 +96,7 @@ class PlaintextValidator:
         min_dictionary_score: float = 0.5,
         min_confidence: float = 0.7,
         log_level: str = "INFO",
+        enable_linguist: bool = False,
     ):
         """Initialize validator.
 
@@ -104,11 +105,36 @@ class PlaintextValidator:
             min_dictionary_score: Minimum dictionary score to pass
             min_confidence: Minimum confidence to mark as valid
             log_level: Logging level
+            enable_linguist: Enable the optional LINGUIST neural-scoring pass
+                (kryptos.agents.linguist.LinguistAgent) in stage 3, alongside the
+                existing heuristic checks. Requires torch/transformers; degrades
+                to disabled (linguist_available=False) if they are unavailable
+                or the agent fails to initialize.
         """
         self.known_cribs = [c.upper() for c in (known_cribs or [])]
         self.min_dictionary_score = min_dictionary_score
         self.min_confidence = min_confidence
         self.log = setup_logging(level=log_level, logger_name="kryptos.pipeline.validator")
+
+        self.linguist = self._init_linguist() if enable_linguist else None
+        self.linguist_available = self.linguist is not None
+
+    def _init_linguist(self) -> Any:
+        try:
+            import torch  # noqa: F401
+            import transformers  # noqa: F401
+        except ImportError:
+            self.log.info("LINGUIST disabled: torch/transformers not available")
+            return None
+
+        try:
+            from kryptos.agents.linguist import LinguistAgent
+            from kryptos.paths import get_data_root
+
+            return LinguistAgent(cache_dir=get_data_root() / "linguist")
+        except Exception as e:
+            self.log.warning(f"LINGUIST agent unavailable: {e}")
+            return None
 
     def normalize(self, text: str) -> str:
         return "".join(c.upper() for c in text if c.isalpha())
@@ -142,7 +168,7 @@ class PlaintextValidator:
                     {
                         "crib": crib,
                         "position": position,
-                        "context": normalized[max(0, position - 5) : position + len(crib) + 5],
+                        "context": normalized[max(0, position - 5) : position + len(crib) + 5],  # noqa: E203
                     },
                 )
 
@@ -159,44 +185,101 @@ class PlaintextValidator:
         normalized = self.normalize(plaintext)
 
         if not normalized:
-            return {
+            result: dict[str, Any] = {
                 "passed": False,
                 "reason": "Empty plaintext",
                 "metrics": {},
             }
+        else:
+            length = len(normalized)
 
-        length = len(normalized)
+            vowels = sum(1 for c in normalized if c in "AEIOUY")
+            vowel_ratio = vowels / length if length > 0 else 0.0
+            vowel_ok = 0.25 < vowel_ratio < 0.55
 
-        vowels = sum(1 for c in normalized if c in "AEIOUY")
-        vowel_ratio = vowels / length if length > 0 else 0.0
-        vowel_ok = 0.25 < vowel_ratio < 0.55
+            max_repeat = max(
+                (len(list(group)) for char, group in __import__("itertools").groupby(normalized)),
+                default=0,
+            )
+            repetition_ok = max_repeat <= 4
 
-        max_repeat = max((len(list(group)) for char, group in __import__('itertools').groupby(normalized)), default=0)
-        repetition_ok = max_repeat <= 4
+            common_digraphs = ["TH", "HE", "IN", "ER", "AN", "RE", "ON", "AT", "EN", "ND"]
+            digraph_count = sum(1 for dg in common_digraphs if dg in normalized)
+            digraph_ok = digraph_count >= 2 or length < 20
 
-        common_digraphs = ["TH", "HE", "IN", "ER", "AN", "RE", "ON", "AT", "EN", "ND"]
-        digraph_count = sum(1 for dg in common_digraphs if dg in normalized)
-        digraph_ok = digraph_count >= 2 or length < 20
+            passed = vowel_ok and repetition_ok and digraph_ok
 
-        passed = vowel_ok and repetition_ok and digraph_ok
+            reasons = []
+            if not vowel_ok:
+                reasons.append(f"Vowel ratio {vowel_ratio:.2%} outside 25-55%")
+            if not repetition_ok:
+                reasons.append(f"Excessive repetition ({max_repeat} consecutive chars)")
+            if not digraph_ok:
+                reasons.append(f"Too few common digraphs ({digraph_count} found)")
 
-        reasons = []
-        if not vowel_ok:
-            reasons.append(f"Vowel ratio {vowel_ratio:.2%} outside 25-55%")
-        if not repetition_ok:
-            reasons.append(f"Excessive repetition ({max_repeat} consecutive chars)")
-        if not digraph_ok:
-            reasons.append(f"Too few common digraphs ({digraph_count} found)")
+            result = {
+                "passed": passed,
+                "metrics": {
+                    "vowel_ratio": vowel_ratio,
+                    "max_repetition": max_repeat,
+                    "common_digraphs": digraph_count,
+                },
+                "reason": " | ".join(reasons) if reasons else "Linguistic checks passed",
+            }
+
+        if self.linguist_available:
+            result["linguist"] = self._linguist_score(plaintext)
+
+        return result
+
+    def _linguist_score(self, plaintext: str) -> dict[str, Any] | None:
+        try:
+            score = self.linguist.validate_candidate(plaintext)
+        except Exception as e:
+            self.log.warning(f"LINGUIST scoring failed: {e}")
+            return None
 
         return {
-            "passed": passed,
-            "metrics": {
-                "vowel_ratio": vowel_ratio,
-                "max_repetition": max_repeat,
-                "common_digraphs": digraph_count,
-            },
-            "reason": " | ".join(reasons) if reasons else "Linguistic checks passed",
+            "confidence": score.confidence,
+            "perplexity": score.perplexity,
+            "coherence": score.coherence,
+            "grammar_score": score.grammar_score,
+            "model_used": score.model_used,
+            "passed": bool(score.metadata.get("passed", False)),
         }
+
+    def batch_validate_linguist(
+        self,
+        candidates: list[str],
+        threshold: float = 0.6,
+        top_k: int = 10,
+    ) -> list[tuple[str, dict[str, Any]]] | None:
+        """Re-rank candidates using the optional LINGUIST agent's batch scoring.
+
+        Returns None if LINGUIST is not enabled/available (see `enable_linguist`).
+        """
+        if not self.linguist_available:
+            return None
+
+        try:
+            scored = self.linguist.batch_validate(candidates, threshold=threshold, top_k=top_k)
+        except Exception as e:
+            self.log.warning(f"LINGUIST batch scoring failed: {e}")
+            return None
+
+        return [
+            (
+                text,
+                {
+                    "confidence": score.confidence,
+                    "perplexity": score.perplexity,
+                    "coherence": score.coherence,
+                    "grammar_score": score.grammar_score,
+                    "model_used": score.model_used,
+                },
+            )
+            for text, score in scored
+        ]
 
     def stage4_confidence_scoring(self, stage_results: dict[str, dict[str, Any]]) -> dict[str, Any]:
         dict_score = stage_results["stage1_dictionary"]["score"]

--- a/tests/functional/test_validator_linguist.py
+++ b/tests/functional/test_validator_linguist.py
@@ -1,0 +1,125 @@
+"""Tests for the optional LINGUIST integration in pipeline/validator.py stage 3."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from kryptos.pipeline.validator import PlaintextValidator
+
+
+@pytest.fixture
+def patched_data_root(tmp_path, monkeypatch):
+    """Keep LINGUIST's on-disk cache under tmp_path instead of the repo's data/ dir."""
+    monkeypatch.setattr("kryptos.paths.get_data_root", lambda: tmp_path)
+    return tmp_path
+
+
+class TestLinguistDisabledByDefault:
+    def test_disabled_by_default(self):
+        validator = PlaintextValidator()
+        assert validator.linguist is None
+        assert validator.linguist_available is False
+
+    def test_stage3_has_no_linguist_key_by_default(self):
+        validator = PlaintextValidator()
+        result = validator.stage3_linguistic_validation("THECLOCKISINBERLIN")
+        assert "linguist" not in result
+
+    def test_batch_validate_linguist_returns_none_by_default(self):
+        validator = PlaintextValidator()
+        assert validator.batch_validate_linguist(["THECLOCKISINBERLIN"]) is None
+
+
+class TestLinguistMissingDependencies:
+    def test_init_linguist_returns_none_without_torch(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", None)
+        validator = PlaintextValidator(enable_linguist=True)
+        assert validator.linguist is None
+        assert validator.linguist_available is False
+
+
+@pytest.fixture
+def linguist_validator(patched_data_root, monkeypatch):
+    """A validator with LINGUIST enabled and perplexity forced to the heuristic path."""
+    validator = PlaintextValidator(enable_linguist=True)
+    if validator.linguist is not None:
+        monkeypatch.setattr(validator.linguist, "_init_perplexity_model", lambda: None)
+    return validator
+
+
+class TestLinguistEnabled:
+    def test_linguist_agent_constructed(self, linguist_validator):
+        if not linguist_validator.linguist_available:
+            pytest.skip("torch/transformers not available")
+        assert linguist_validator.linguist is not None
+
+    def test_stage3_includes_linguist_score(self, linguist_validator):
+        if not linguist_validator.linguist_available:
+            pytest.skip("torch/transformers not available")
+
+        result = linguist_validator.stage3_linguistic_validation("THECLOCKISINBERLIN")
+
+        # Existing heuristic fields are unchanged.
+        assert "passed" in result
+        assert "metrics" in result
+        assert "reason" in result
+
+        ling = result["linguist"]
+        assert ling is not None
+        assert 0.0 <= ling["confidence"] <= 1.0
+        assert ling["perplexity"] > 0
+        assert 0.0 <= ling["coherence"] <= 1.0
+        assert 0.0 <= ling["grammar_score"] <= 1.0
+        assert "model_used" in ling
+        assert isinstance(ling["passed"], bool)
+
+    def test_stage3_empty_text_includes_linguist_score(self, linguist_validator):
+        if not linguist_validator.linguist_available:
+            pytest.skip("torch/transformers not available")
+
+        result = linguist_validator.stage3_linguistic_validation("")
+        assert result["passed"] is False
+        assert result["linguist"] is not None
+
+    def test_batch_validate_linguist(self, linguist_validator):
+        if not linguist_validator.linguist_available:
+            pytest.skip("torch/transformers not available")
+
+        candidates = [
+            "THE CLOCK IS HIDDEN IN BERLIN NEAR THE WALL",
+            "XQZMWPVUTRSLKJIHGFEDCBA",
+        ]
+        ranked = linguist_validator.batch_validate_linguist(candidates, threshold=0.0, top_k=5)
+
+        assert ranked is not None
+        assert len(ranked) >= 1
+        for text, score in ranked:
+            assert text in candidates
+            assert 0.0 <= score["confidence"] <= 1.0
+
+
+class TestLinguistScoringFailure:
+    def test_linguist_score_handles_exception(self, linguist_validator, monkeypatch):
+        if not linguist_validator.linguist_available:
+            pytest.skip("torch/transformers not available")
+
+        def _raise(_text: str):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(linguist_validator.linguist, "validate_candidate", _raise)
+
+        result = linguist_validator.stage3_linguistic_validation("THECLOCKISINBERLIN")
+        assert result["linguist"] is None
+
+    def test_batch_validate_linguist_handles_exception(self, linguist_validator, monkeypatch):
+        if not linguist_validator.linguist_available:
+            pytest.skip("torch/transformers not available")
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(linguist_validator.linguist, "batch_validate", _raise)
+
+        assert linguist_validator.batch_validate_linguist(["THECLOCKISINBERLIN"]) is None


### PR DESCRIPTION
## Summary
- Adds an `enable_linguist` flag (default `False`) to `PlaintextValidator`. When enabled, `_init_linguist()` gates on `torch`/`transformers` and `LinguistAgent` construction, degrading gracefully to `linguist_available=False` on any failure (mirroring `SpyAgent`'s optional-dependency pattern).
- `stage3_linguistic_validation()` adds a `"linguist"` key (confidence/perplexity/coherence/grammar_score/model_used/passed) alongside the existing heuristic checks when enabled; absent entirely by default.
- New `batch_validate_linguist()` re-ranks candidates via `LinguistAgent.batch_validate`, returning `None` when LINGUIST is disabled/unavailable or scoring fails.
- Adds `/data/linguist/` to `.gitignore` (model cache dir created by `_init_linguist()`).
- Updates `docs/reference/AGENTS_ARCHITECTURE.md`, `ROADMAP.md`, `TASKS.md` to reflect the completed integration (was the top TASKS.md Todo item from the Agent Module Review).

Closes the "Linguist integration" item in `TASKS.md`.

## Test plan
- [x] New `tests/functional/test_validator_linguist.py` (10 tests): default-disabled behavior, missing-`torch` graceful degradation, enabled-path stage3/`batch_validate_linguist` (with `_init_perplexity_model` monkeypatched to avoid network calls), and exception-handling fallbacks — all pass in Docker (`kryptos-agent-review` image, 6.11s).
- [x] `tests/smoke/test_fast_coverage_targets.py::test_validator_scoring_and_validation_paths` — no regression (default `enable_linguist=False` path unchanged).
- [x] Full `pytest -m "not slow"` suite (913 tests, excluding pre-existing `test_api.py` fastapi-import issue unrelated to this change) — 913 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)