### PR TITLE
fix(deps): add psycopg2-binary for kryptos.db Postgres/Neon storage

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -13,3 +13,4 @@ sentence-transformers>=5.5.1  # Embeddings for kryptos.rag turbovec index (also 
 turbovec  # Compressed vector index for kryptos.rag (RAG over artifacts/)
 fastapi>=0.115  # `kryptos serve` API
 uvicorn[standard]>=0.34  # ASGI server for `kryptos serve`
+psycopg2-binary>=2.9  # PostgreSQL driver for kryptos.db (DATABASE_URL / Neon storage)

--- a/tests/functional/test_db.py
+++ b/tests/functional/test_db.py
@@ -1,0 +1,33 @@
+"""Tests for kryptos.db — DATABASE_URL connection helper."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from kryptos.db import get_conn, get_db_url
+
+
+class TestGetDbUrl:
+    def test_raises_without_database_url(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        with pytest.raises(RuntimeError, match="DATABASE_URL"):
+            get_db_url()
+
+    def test_returns_url_unchanged(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/db")
+        assert get_db_url() == "postgresql://user:pass@host/db"
+
+    def test_strips_inline_comment(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/db  # comment")
+        assert get_db_url() == "postgresql://user:pass@host/db"
+
+
+@pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="DATABASE_URL not set")
+class TestGetConnLive:
+    def test_get_conn_executes_query(self):
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                assert cur.fetchone() == (1,)


### PR DESCRIPTION
## Summary
- `kryptos.db.get_conn()` (used by `ops_director`'s `strategy_kb`/`ops_decisions` persistence and `spy_web_intel`'s crib storage) imports `psycopg2`, but it was never declared in `config/requirements.txt`. Both call sites already catch the resulting `ImportError` and fall back to file-based storage, so nothing crashed — but the Postgres/Neon path was always silently dead.
- Adds `psycopg2-binary>=2.9` to `config/requirements.txt`.
- Adds `tests/functional/test_db.py`: unit tests for `get_db_url()` (missing-env error, inline-comment stripping) plus a live `SELECT 1` round-trip test that's skipped unless `DATABASE_URL` is set (not set in CI, so it skips there — same opt-in pattern as the LINGUIST integration).

This is prep work for the Q1 2027 Phase 2/3 dashboard/API roadmap items (Neon-backed `candidates`/`campaign_runs`/`strategy_kb` storage).

## Test plan
- [x] `tests/functional/test_db.py` (4 tests): 3 pass always, live-connection test passes against a real Neon Postgres instance with `DATABASE_URL` set + `psycopg2-binary` installed (verified in Docker), and skips cleanly without it.
- [x] Full `pytest -m "not slow"` suite (916 tests, excluding pre-existing `test_api.py` fastapi-import issue unrelated to this change) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)