### PR TITLE
fix: seed RNG in flaky hill_genetic GA tests

### DIFF
--- a/tests/functional/test_hill_genetic.py
+++ b/tests/functional/test_hill_genetic.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import random
+
 import pytest
 
 from kryptos.k4.hill_cipher import hill_decrypt, hill_encrypt, matrix_inv_mod
@@ -136,6 +138,10 @@ def test_genetic_algorithm_hill3x3():
 
     Note: This is a slow test (~10-30 seconds) due to GA iterations.
     """
+    # The GA draws from the global `random` module; seed it so the score
+    # threshold below is deterministic rather than a lottery across runs
+    random.seed(42)
+
     # Create a simple known plaintext/ciphertext pair
     plaintext = "EASTBERLINCLOCKX"  # 16 chars (multiple of 3 with padding)
     # Pad to multiple of 3
@@ -180,6 +186,9 @@ def test_genetic_algorithm_convergence():
 
     Uses a simple test case to verify the algorithm improves scores.
     """
+    # Seed for determinism (the GA draws from the global `random` module)
+    random.seed(1234)
+
     # Simple plaintext with good English characteristics
     plaintext = "THISISATESTTHATCONTAINSCOMMONENGLISHLETTERS"
     # Pad to multiple of 3


### PR DESCRIPTION
## Summary
- `test_genetic_algorithm_hill3x3` intermittently fails with `assert -123.52 > -100`: it runs an unseeded 20-generation genetic algorithm and asserts on the resulting score, so an unlucky initial population fails the threshold (observed in a local full-suite run; the same test passed on PR #91 CI an hour earlier).
- Fix: seed the global `random` module (which `kryptos.k4.hill_genetic` draws from) at the start of both stochastic tests (`random.seed(42)` / `random.seed(1234)`), making the assertions deterministic.

## Test plan
- [x] `pytest tests/functional/test_hill_genetic.py` in Docker — 8/8 pass (1.3s)
- [x] Re-ran the two seeded tests in isolation — deterministic pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)