### PR TITLE
feat: add Neon/Postgres schema module + kryptos db-init CLI

### DIFF
--- a/docs/reference/AGENTS_ARCHITECTURE.md
+++ b/docs/reference/AGENTS_ARCHITECTURE.md
@@ -102,7 +102,9 @@ Strategy knowledge (`strategy_kb` table) is read by `OpsStrategicDirector` on in
   model is **not** installed in the runtime Docker image; `SpyAgent` degrades
   gracefully (`nlp_available = False`) when it is missing.
 - **`ops_director` LLM paths** require `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`; both fall back to rule-based logic if absent
-- **DB writes** require `DATABASE_URL` in environment (see `kryptos.db`)
+- **DB writes** require `DATABASE_URL` in environment (see `kryptos.db`). Tables are
+  defined in `kryptos.db_schema` and created idempotently with `kryptos db-init`
+  (`strategy_kb`, `ops_decisions`, `discovered_cribs`, `campaign_runs`, `candidates`).
 
 ---
 
@@ -118,6 +120,7 @@ Strategy knowledge (`strategy_kb` table) is read by `OpsStrategicDirector` on in
 | `tests/functional/test_linguist.py` | Linguist scoring |
 | `tests/functional/test_validator_linguist.py` | LINGUIST integration in `pipeline/validator.py` stage 3 (opt-in, graceful degradation) |
 | `tests/functional/test_spy_*.py` | SPY pattern analysis |
+| `tests/functional/test_db_schema.py` | `kryptos.db_schema` table definitions + live round-trips of the agent SQL shapes |
 | `tests/smoke/test_cli_subcommands.py` | CLI entry points |
 
 ---

--- a/src/kryptos/cli/main.py
+++ b/src/kryptos/cli/main.py
@@ -306,6 +306,9 @@ def build_parser() -> argparse.ArgumentParser:
     sp_serve.add_argument("--reload", action="store_true", help="Enable auto-reload (development)")
     sp_serve.set_defaults(func=cmd_serve)
 
+    sp_db_init = sub.add_parser("db-init", help="Create kryptos Postgres/Neon tables (requires DATABASE_URL)")
+    sp_db_init.set_defaults(func=cmd_db_init)
+
     return parser
 
     p = argparse.ArgumentParser(prog="kryptos", description="Kryptos research CLI")
@@ -450,6 +453,19 @@ def cmd_serve(args: argparse.Namespace) -> int:
     import uvicorn
 
     uvicorn.run("kryptos.api.app:app", host=args.host, port=args.port, reload=args.reload)
+    return 0
+
+
+def cmd_db_init(args: argparse.Namespace) -> int:
+    """Create the kryptos Postgres/Neon tables if they do not exist."""
+    try:
+        from kryptos.db_schema import init_schema
+
+        tables = init_schema()
+    except (RuntimeError, ImportError) as exc:
+        print(f"db-init failed: {exc}")
+        return 1
+    print(f"Ensured {len(tables)} tables: {', '.join(tables)}")
     return 0
 
 

--- a/src/kryptos/db_schema.py
+++ b/src/kryptos/db_schema.py
@@ -1,0 +1,119 @@
+"""Neon/Postgres schema for kryptos persistent storage.
+
+Defines the tables that agent and pipeline code already target (or will):
+
+- ``strategy_kb`` — read by ``OpsStrategicDirector._load_strategy_kb``
+- ``ops_decisions`` — written by ``OpsStrategicDirector._save_decision``
+- ``discovered_cribs`` — read/written by ``SpyWebIntel._load_cache``/``_save_cache``
+- ``campaign_runs`` / ``candidates`` — Phase 3 candidate & run storage
+  (currently file-based under ``artifacts/``; shapes mirror ``k4.reporting``)
+
+All DDL is idempotent (``CREATE TABLE IF NOT EXISTS``), so ``init_schema()``
+can run safely on every deploy. Apply with ``kryptos db-init`` or::
+
+    from kryptos.db_schema import init_schema
+    init_schema()
+"""
+
+from __future__ import annotations
+
+# Mapping of table name -> idempotent DDL (table + its indexes).
+SCHEMA_STATEMENTS: dict[str, str] = {
+    "strategy_kb": """
+        CREATE TABLE IF NOT EXISTS strategy_kb (
+            id          BIGSERIAL PRIMARY KEY,
+            category    TEXT NOT NULL CHECK (category IN ('successful', 'failed', 'lesson')),
+            description TEXT NOT NULL,
+            attack_type TEXT,
+            confidence  DOUBLE PRECISION,
+            metadata    JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+        );
+    """,
+    "ops_decisions": """
+        CREATE TABLE IF NOT EXISTS ops_decisions (
+            id               BIGSERIAL PRIMARY KEY,
+            timestamp        TIMESTAMPTZ NOT NULL,
+            action           TEXT NOT NULL,
+            reasoning        TEXT,
+            affected_attacks TEXT[] NOT NULL DEFAULT '{}',
+            resource_changes JSONB NOT NULL DEFAULT '{}'::jsonb,
+            success_criteria TEXT,
+            review_in_hours  DOUBLE PRECISION,
+            confidence       DOUBLE PRECISION
+        );
+    """,
+    "discovered_cribs": """
+        CREATE TABLE IF NOT EXISTS discovered_cribs (
+            id         BIGSERIAL PRIMARY KEY,
+            text       TEXT NOT NULL UNIQUE,
+            source     TEXT NOT NULL,
+            confidence DOUBLE PRECISION NOT NULL,
+            category   TEXT,
+            context    TEXT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        );
+    """,
+    "campaign_runs": """
+        CREATE TABLE IF NOT EXISTS campaign_runs (
+            id           BIGSERIAL PRIMARY KEY,
+            label        TEXT,
+            stage        TEXT,
+            cipher_label TEXT,
+            ciphertext   TEXT,
+            status       TEXT NOT NULL DEFAULT 'running',
+            started_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+            finished_at  TIMESTAMPTZ,
+            metadata     JSONB NOT NULL DEFAULT '{}'::jsonb
+        );
+    """,
+    "candidates": """
+        CREATE TABLE IF NOT EXISTS candidates (
+            id              BIGSERIAL PRIMARY KEY,
+            campaign_run_id BIGINT REFERENCES campaign_runs(id) ON DELETE SET NULL,
+            rank            INTEGER,
+            score           DOUBLE PRECISION,
+            source          TEXT,
+            key             JSONB,
+            key_hash        TEXT,
+            text            TEXT NOT NULL,
+            metrics         JSONB NOT NULL DEFAULT '{}'::jsonb,
+            origin_stage    TEXT,
+            lineage         JSONB,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+        );
+        CREATE INDEX IF NOT EXISTS idx_candidates_score ON candidates (score DESC);
+        CREATE INDEX IF NOT EXISTS idx_candidates_run ON candidates (campaign_run_id);
+    """,
+}
+
+
+def init_schema(conn=None) -> list[str]:
+    """Create all kryptos tables if they do not exist.
+
+    Args:
+        conn: Optional open psycopg2 connection. When omitted, a connection
+            is opened via :func:`kryptos.db.get_conn` (requires DATABASE_URL).
+
+    Returns:
+        Sorted list of table names ensured.
+    """
+    if conn is not None:
+        _apply(conn)
+    else:
+        from kryptos.db import get_conn
+
+        with get_conn() as owned_conn:
+            _apply(owned_conn)
+    return sorted(SCHEMA_STATEMENTS)
+
+
+def _apply(conn) -> None:
+    with conn.cursor() as cur:
+        # campaign_runs must exist before candidates (FK), so apply in
+        # definition order rather than sorted order.
+        for ddl in SCHEMA_STATEMENTS.values():
+            cur.execute(ddl)
+
+
+__all__ = ["SCHEMA_STATEMENTS", "init_schema"]

--- a/tests/functional/test_db_schema.py
+++ b/tests/functional/test_db_schema.py
@@ -1,0 +1,186 @@
+"""Tests for kryptos.db_schema — Neon/Postgres table definitions."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from kryptos.db_schema import SCHEMA_STATEMENTS, init_schema
+
+EXPECTED_TABLES = {"strategy_kb", "ops_decisions", "discovered_cribs", "campaign_runs", "candidates"}
+
+# Marker so live tests never collide with (or delete) real rows
+_TEST_TAG = "__kryptos_test__"
+
+
+class TestSchemaStatements:
+    def test_expected_tables_defined(self):
+        assert set(SCHEMA_STATEMENTS) == EXPECTED_TABLES
+
+    def test_all_ddl_idempotent(self):
+        for name, ddl in SCHEMA_STATEMENTS.items():
+            assert "CREATE TABLE IF NOT EXISTS" in ddl, name
+            # Idempotent indexes too, if any
+            assert "CREATE INDEX " not in ddl.replace("CREATE INDEX IF NOT EXISTS", ""), name
+
+    def test_campaign_runs_defined_before_candidates(self):
+        """candidates has an FK to campaign_runs, so definition order matters."""
+        names = list(SCHEMA_STATEMENTS)
+        assert names.index("campaign_runs") < names.index("candidates")
+
+    def test_init_schema_returns_tables_without_executing(self):
+        """With an explicit conn, init_schema must not import kryptos.db."""
+
+        class FakeCursor:
+            executed: list[str] = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def execute(self, sql):
+                FakeCursor.executed.append(sql)
+
+        class FakeConn:
+            def cursor(self):
+                return FakeCursor()
+
+        FakeCursor.executed = []
+        tables = init_schema(conn=FakeConn())
+        assert tables == sorted(EXPECTED_TABLES)
+        assert len(FakeCursor.executed) == len(EXPECTED_TABLES)
+
+
+@pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="DATABASE_URL not set")
+class TestSchemaLive:
+    """Round-trip tests against a live database, using the exact SQL shapes
+    that ops_director.py and spy_web_intel.py issue."""
+
+    @pytest.fixture(autouse=True)
+    def _schema(self):
+        init_schema()
+        yield
+        # Remove any rows this test class created
+        from kryptos.db import get_conn
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM strategy_kb WHERE description LIKE %s", (f"{_TEST_TAG}%",))
+                cur.execute("DELETE FROM ops_decisions WHERE reasoning LIKE %s", (f"{_TEST_TAG}%",))
+                cur.execute("DELETE FROM discovered_cribs WHERE text LIKE %s", (f"{_TEST_TAG}%",))
+                cur.execute("DELETE FROM candidates WHERE text LIKE %s", (f"{_TEST_TAG}%",))
+                cur.execute("DELETE FROM campaign_runs WHERE label LIKE %s", (f"{_TEST_TAG}%",))
+
+    def test_init_schema_idempotent(self):
+        assert init_schema() == sorted(EXPECTED_TABLES)
+        assert init_schema() == sorted(EXPECTED_TABLES)
+
+    def test_strategy_kb_roundtrip(self):
+        from kryptos.db import get_conn
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO strategy_kb (category, description, attack_type, confidence, metadata)"
+                    " VALUES (%s, %s, %s, %s, %s::jsonb)",
+                    ("lesson", f"{_TEST_TAG} hill climbing stalls", "hill", 0.7, json.dumps({"k": 1})),
+                )
+                # Exact read shape from OpsStrategicDirector._load_strategy_kb
+                cur.execute(
+                    "SELECT category, description, attack_type, confidence, metadata FROM strategy_kb ORDER BY id"
+                )
+                rows = [r for r in cur.fetchall() if r[1].startswith(_TEST_TAG)]
+        assert rows == [("lesson", f"{_TEST_TAG} hill climbing stalls", "hill", 0.7, {"k": 1})]
+
+    def test_strategy_kb_rejects_unknown_category(self):
+        from kryptos.db import get_conn
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                with pytest.raises(Exception, match="strategy_kb_category_check"):
+                    cur.execute(
+                        "INSERT INTO strategy_kb (category, description) VALUES (%s, %s)",
+                        ("bogus", f"{_TEST_TAG} nope"),
+                    )
+
+    def test_ops_decisions_insert(self):
+        from kryptos.db import get_conn
+
+        # Exact insert shape from OpsStrategicDirector._save_decision
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO ops_decisions
+                       (timestamp, action, reasoning, affected_attacks, resource_changes,
+                        success_criteria, review_in_hours, confidence)
+                       VALUES (%s, %s, %s, %s, %s::jsonb, %s, %s, %s)""",
+                    (
+                        datetime.now(timezone.utc),
+                        "reallocate",
+                        f"{_TEST_TAG} test decision",
+                        ["hill", "vigenere"],
+                        json.dumps({"hill": 0.5}),
+                        "improvement",
+                        2.0,
+                        0.8,
+                    ),
+                )
+                cur.execute(
+                    "SELECT action, affected_attacks, resource_changes FROM ops_decisions WHERE reasoning LIKE %s",
+                    (f"{_TEST_TAG}%",),
+                )
+                row = cur.fetchone()
+        assert row == ("reallocate", ["hill", "vigenere"], {"hill": 0.5})
+
+    def test_discovered_cribs_upsert(self):
+        from kryptos.db import get_conn
+
+        crib = f"{_TEST_TAG}LANGLEY"
+        # Exact upsert shape from SpyWebIntel._save_cache, run twice to hit ON CONFLICT
+        upsert = """INSERT INTO discovered_cribs (text, source, confidence, category, context)
+                    VALUES (%s, %s, %s, %s, %s)
+                    ON CONFLICT (text) DO UPDATE
+                        SET confidence = EXCLUDED.confidence,
+                            source     = EXCLUDED.source,
+                            category   = EXCLUDED.category,
+                            context    = EXCLUDED.context"""
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(upsert, (crib, "test", 0.5, "location", "first"))
+                cur.execute(upsert, (crib, "test2", 0.9, "location", "second"))
+                # Exact read shape from SpyWebIntel._load_cache
+                cur.execute(
+                    "SELECT text, confidence, source, context, created_at, category FROM discovered_cribs"
+                    " WHERE text = %s",
+                    (crib,),
+                )
+                rows = cur.fetchall()
+        assert len(rows) == 1
+        text, confidence, source, context, created_at, category = rows[0]
+        assert (text, confidence, source, context, category) == (crib, 0.9, "test2", "second", "location")
+        assert created_at is not None
+
+    def test_candidates_fk_to_campaign_runs(self):
+        from kryptos.db import get_conn
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO campaign_runs (label, stage, cipher_label, status) VALUES (%s, %s, %s, %s)"
+                    " RETURNING id",
+                    (f"{_TEST_TAG}run", "stage1", "K4", "complete"),
+                )
+                run_id = cur.fetchone()[0]
+                cur.execute(
+                    "INSERT INTO candidates (campaign_run_id, rank, score, text, key, metrics)"
+                    " VALUES (%s, %s, %s, %s, %s::jsonb, %s::jsonb)",
+                    (run_id, 1, -12.5, f"{_TEST_TAG}EASTNORTHEAST", json.dumps([[1, 2], [3, 4]]), json.dumps({})),
+                )
+                cur.execute("SELECT rank, score, key FROM candidates WHERE campaign_run_id = %s", (run_id,))
+                row = cur.fetchone()
+        assert row == (1, -12.5, [[1, 2], [3, 4]])

--- a/tests/smoke/test_cli_subcommands.py
+++ b/tests/smoke/test_cli_subcommands.py
@@ -11,111 +11,119 @@ def _invoke(argv: list[str]):
 
 
 def test_sections(capsys):
-    _invoke(['sections'])
+    _invoke(["sections"])
     out = capsys.readouterr().out.strip().splitlines()
-    assert 'K1' in out and 'K4' in out
+    assert "K1" in out and "K4" in out
+
+
+def test_db_init_fails_cleanly_without_database_url(monkeypatch, capsys):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    rc = _invoke(["db-init"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "db-init failed" in out
 
 
 def test_k4_decrypt_minimal(tmp_path: Path, capsys):
-    cipher_file = tmp_path / 'cipher.txt'
-    cipher_file.write_text('OBKRUOXOGHULBSOLIFB', encoding='utf-8')
-    _invoke(['k4-decrypt', '--cipher', str(cipher_file), '--limit', '5'])
+    cipher_file = tmp_path / "cipher.txt"
+    cipher_file.write_text("OBKRUOXOGHULBSOLIFB", encoding="utf-8")
+    _invoke(["k4-decrypt", "--cipher", str(cipher_file), "--limit", "5"])
     out = capsys.readouterr().out
     data = json.loads(out)
-    assert 'plaintext' in data and 'score' in data
+    assert "plaintext" in data and "score" in data
 
 
 def test_tuning_holdout_score_no_write(capsys):
-    _invoke(['tuning-holdout-score', '--weight', '1.0', '--no-write'])
+    _invoke(["tuning-holdout-score", "--weight", "1.0", "--no-write"])
     out = capsys.readouterr().out
     data = json.loads(out)
-    assert data['weight'] == 1.0
-    assert 'rows' in data and len(data['rows']) >= 1
+    assert data["weight"] == 1.0
+    assert "rows" in data and len(data["rows"]) >= 1
 
 
 def test_tuning_tiny_param_sweep(capsys):
-    _invoke(['tuning-tiny-param-sweep'])
+    _invoke(["tuning-tiny-param-sweep"])
     out = capsys.readouterr().out
     rows = json.loads(out)
     assert isinstance(rows, list)
 
 
 def test_tuning_crib_weight_sweep_json(capsys):
-    _invoke(['tuning-crib-weight-sweep', '--weights', '0.5,1.0', '--json'])
+    _invoke(["tuning-crib-weight-sweep", "--weights", "0.5,1.0", "--json"])
     out = capsys.readouterr().out
     rows = json.loads(out)
     assert len(rows) >= 2
-    assert {'weight', 'delta'} <= set(rows[0].keys())
+    assert {"weight", "delta"} <= set(rows[0].keys())
 
 
 def test_tuning_pick_best(tmp_path: Path, capsys):
     # Create a minimal CSV and run pick-best
-    csv_path = tmp_path / 'crib_weight_sweep.csv'
+    csv_path = tmp_path / "crib_weight_sweep.csv"
     csv_path.write_text(
-        'weight,sample,baseline,with_cribs,delta\n1.0,SAMP,0.0,1.0,1.0\n0.5,SAMP,0.0,0.8,0.8\n',
-        encoding='utf-8',
+        "weight,sample,baseline,with_cribs,delta\n1.0,SAMP,0.0,1.0,1.0\n0.5,SAMP,0.0,0.8,0.8\n",
+        encoding="utf-8",
     )
-    _invoke(['tuning-pick-best', '--csv', str(csv_path)])
+    _invoke(["tuning-pick-best", "--csv", str(csv_path)])
     out = capsys.readouterr().out
     data = json.loads(out)
-    assert data['best_weight'] == 1.0
+    assert data["best_weight"] == 1.0
 
 
 def _make_fake_run(root: Path) -> Path:
-    run_dir = root / 'run_20250101T000000'
+    run_dir = root / "run_20250101T000000"
     run_dir.mkdir(parents=True, exist_ok=True)
     # minimal files for summarize_run: attempts.json & weight sweep mock
-    (run_dir / 'attempts.json').write_text('[]', encoding='utf-8')
-    (run_dir / 'crib_weight_sweep.csv').write_text(
-        'weight,sample,baseline,with_cribs,delta\n1.0,SAMP,0.0,1.0,1.0\n',
-        encoding='utf-8',
+    (run_dir / "attempts.json").write_text("[]", encoding="utf-8")
+    (run_dir / "crib_weight_sweep.csv").write_text(
+        "weight,sample,baseline,with_cribs,delta\n1.0,SAMP,0.0,1.0,1.0\n",
+        encoding="utf-8",
     )
     # add a detail file to allow condensed report
-    (run_dir / 'weight_1_0_details.csv').write_text(
-        'sample,delta\nSAMP,1.0\n',
-        encoding='utf-8',
+    (run_dir / "weight_1_0_details.csv").write_text(
+        "sample,delta\nSAMP,1.0\n",
+        encoding="utf-8",
     )
     return run_dir
 
 
 def test_tuning_summarize_run(tmp_path: Path, capsys):
     run_dir = _make_fake_run(tmp_path)
-    _invoke(['tuning-summarize-run', '--run-dir', str(run_dir), '--no-write'])
+    _invoke(["tuning-summarize-run", "--run-dir", str(run_dir), "--no-write"])
     out = capsys.readouterr().out
     data = json.loads(out)
-    assert 'crib_hit_counts' in data or 'summary' in data
+    assert "crib_hit_counts" in data or "summary" in data
 
 
 def test_spy_eval(tmp_path: Path, capsys):
     # fabricate runs + labels
-    runs_root = tmp_path / 'tuning_runs'
+    runs_root = tmp_path / "tuning_runs"
     runs_root.mkdir()
-    rdir = runs_root / 'run_20250101T000001'
+    rdir = runs_root / "run_20250101T000001"
     rdir.mkdir()
     # fabricate extractor-compatible file for spy-eval path (simulate tokens) if needed
-    labels_csv = tmp_path / 'labels.csv'
-    labels_csv.write_text('run_20250101T000001,TESTTOKEN\n', encoding='utf-8')
-    _invoke(['spy-eval', '--labels', str(labels_csv), '--runs', str(runs_root), '--thresholds', '0.0'])
+    labels_csv = tmp_path / "labels.csv"
+    labels_csv.write_text("run_20250101T000001,TESTTOKEN\n", encoding="utf-8")
+    _invoke(["spy-eval", "--labels", str(labels_csv), "--runs", str(runs_root), "--thresholds", "0.0"])
     out = capsys.readouterr().out
     data = json.loads(out)
-    assert 'thresholds' in data and '0.00' in data['thresholds']
+    assert "thresholds" in data and "0.00" in data["thresholds"]
 
 
 def test_spy_extract(tmp_path: Path, capsys):
-    runs_root = tmp_path / 'tuning_runs'
+    runs_root = tmp_path / "tuning_runs"
     runs_root.mkdir()
-    (runs_root / 'run_20250101T000002').mkdir()
-    _invoke(['spy-extract', '--runs', str(runs_root), '--min-conf', '0.25'])
+    (runs_root / "run_20250101T000002").mkdir()
+    _invoke(["spy-extract", "--runs", str(runs_root), "--min-conf", "0.25"])
     out = capsys.readouterr().out
     data = json.loads(out)
-    assert 'min_conf' in data and 'extracted' in data
+    assert "min_conf" in data and "extracted" in data
 
 
 def test_tuning_report(tmp_path: Path, capsys):
-    runs_root = tmp_path / 'tuning_runs'
+    runs_root = tmp_path / "tuning_runs"
     run_dir = _make_fake_run(runs_root)
-    _invoke(['tuning-report', '--run-dir', str(run_dir), '--top-n', '1'])
+    _invoke(["tuning-report", "--run-dir", str(run_dir), "--top-n", "1"])
     out = capsys.readouterr().out
     data = json.loads(out)
-    assert 'condensed_csv' in data
-    assert data['markdown'] is not None
+    assert "condensed_csv" in data
+    assert data["markdown"] is not None


### PR DESCRIPTION
## Summary
- Adds `kryptos.db_schema` defining the five tables the codebase targets: `strategy_kb` + `ops_decisions` (read/written by `OpsStrategicDirector`), `discovered_cribs` (`SpyWebIntel` cache), and Phase 3 `campaign_runs`/`candidates` (column shapes mirror the `k4.reporting` artifact output). Until now every agent DB path silently fell back to file storage because the tables didn't exist.
- `init_schema()` applies idempotent `CREATE TABLE IF NOT EXISTS` DDL in FK-safe order; new `kryptos db-init` CLI subcommand wraps it (clean error + exit 1 without `DATABASE_URL`/psycopg2).
- The schema is already applied to the live Neon DB.

## Test plan
- [x] `tests/functional/test_db_schema.py`: schema-shape unit tests + live round-trips using the **exact SQL strings** the agents issue (`_load_strategy_kb` select, `_save_decision` insert, `_save_cache` upsert + `ON CONFLICT`), candidates↔campaign_runs FK — 10/10 pass against live Neon in Docker; live tests skip cleanly without `DATABASE_URL` (as in CI)
- [x] `tests/smoke/test_cli_subcommands.py::test_db_init_fails_cleanly_without_database_url`
- [x] `kryptos db-init` run live in Docker: "Ensured 5 tables: campaign_runs, candidates, discovered_cribs, ops_decisions, strategy_kb"
- [x] Full suite in rebuilt Docker image: 927 passed; 6 failures are pre-existing bind-mount/permission artifacts of the local test setup (pass in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)