### PR TITLE
feat: Quagmire I-IV cipher family + systematic K4 sweep (null result)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-06-11
+Last Updated: 2026-06-12
 
 
 ## Todo
@@ -31,6 +31,11 @@ Last Updated: 2026-06-11
 ## In Progress
 
 ## Done
+
+### Quagmire I–IV solver + K4 sweep
+
+- [x] **`kryptos.k4.quagmire`** — canonical encrypt/decrypt for Quagmire I–IV (keyed plaintext/ciphertext alphabets, both Kryptos first-letter and ACA indicator-base conventions). Ground-truth verified: Quagmire III with the KRYPTOS tableau exactly reproduces K1 (PALIMPSEST) and K2 (ABSCISSA) plaintexts.
+- [x] **`kryptos.k4.quagmire_sweep.run_quagmire_sweep`** — 6,240 combinations against K4: Q1/Q2/Q3 × 4 alphabet keywords × 10 word keys × 2 indicator bases, Q4 ordered keyword pairs, plus Q3 with 1,440 Berlin Clock minute-state indicator keys. Positional crib gating (EAST@22/NORTHEAST@26/BERLIN@63/CLOCK@69) + EurekaSignal protocol. **Null result** — rules out pure single-layer Quagmire, reinforcing the substitution+transposition composite model. Artifact: `K4_QUAGMIRE_NULL.json`; recorded in `docs/analysis/K4_ACTIVE_RESEARCH.md`.
 
 ### Agent Module Review (Post-K4, Pre-GUI)
 

--- a/docs/analysis/K4_ACTIVE_RESEARCH.md
+++ b/docs/analysis/K4_ACTIVE_RESEARCH.md
@@ -42,6 +42,7 @@ This document tracks what is currently known, what has been tested and ruled out
 | ENE diagonal route transposition (67.5°) with clock-Vigenère | NULL RESULT | `read_ene_diagonal` integrated into full sweep; all route variants tested. No breakthrough. |
 | ADFGVX (Polybius + columnar transposition) | NULL RESULT | Implemented (`kryptos.k4.adfgvx`) and tested against K4; no crib match |
 | Nihilist (Polybius + numeric key) | NULL RESULT | Implemented (`kryptos.k4.nihilist`) and tested against K4; no crib match |
+| Pure (single-layer) Quagmire I–IV | NULL RESULT | `run_quagmire_sweep` — 6,240 combinations: Q1/Q2/Q3 × 4 alphabet keywords × 10 word keys × 2 indicator bases, Q4 ordered keyword pairs, plus Q3 × 1,440 Berlin Clock minute-state indicator keys on the KRYPTOS tableau. Zero positional crib or keyword hits. Artifact: `K4_QUAGMIRE_NULL.json`. Reinforces the substitution+transposition composite model — implementation verified by exactly reproducing K1/K2 (Quagmire III, KRYPTOS tableau). |
 
 ---
 
@@ -180,6 +181,8 @@ This was mentioned in `K4-T1.md` and `30_YEAR_GAP_COVERAGE.md` but the composite
 | Non-standard Berlin Clock sub-row encodings | ✅ Implemented | `kryptos.k4.clock_subrow_attack.run_clock_subrow_attack` — 4 sub-row schemes as short Vigenère keys. |
 | Berlin Clock lamp counts as transposition column widths | ✅ Implemented | `kryptos.k4.clock_subrow_attack.run_clock_transposition_attack` — lamp values as columnar transposition widths. |
 | Beaufort sweep against K4 | ✅ Implemented | `kryptos.k4.beaufort_sweep.run_beaufort_sweep` — 10 key candidates × 2 alphabets. |
+| Quagmire I–IV primitives | ✅ Complete | `kryptos.k4.quagmire` — canonical encrypt/decrypt for all four variants; Q3 with KRYPTOS tableau exactly reproduces K1/K2 (ground-truth tested). |
+| Quagmire sweep against K4 | ✅ Complete | `kryptos.k4.quagmire_sweep.run_quagmire_sweep` — Q1–Q4 word keys + Q3 Berlin Clock minute-state indicator keys; positional crib gating; null result. |
 
 ---
 

--- a/src/kryptos/k4/quagmire.py
+++ b/src/kryptos/k4/quagmire.py
@@ -1,0 +1,134 @@
+"""Quagmire cipher family (ACA Quagmire I-IV) — keyed-alphabet periodic substitution.
+
+The Quagmire ciphers are Vigenere-style periodic substitutions where the
+plaintext and/or ciphertext alphabets are keyword-mixed:
+
+- **Quagmire I**   — keyed plaintext alphabet, straight ciphertext alphabet
+- **Quagmire II**  — straight plaintext alphabet, keyed ciphertext alphabet
+- **Quagmire III** — the *same* keyed alphabet on both sides
+- **Quagmire IV**  — *different* keyed alphabets on each side
+
+All four share one core relation. With plaintext alphabet ``PT``, ciphertext
+alphabet ``CT``, indicator key letter ``k`` for the current period, and an
+indicator base letter ``b`` (the plaintext-alphabet letter the key letter is
+written under):
+
+    C = CT[(PT.index(P) + CT.index(k) - PT.index(b)) % 26]
+    P = PT[(CT.index(C) - CT.index(k) + PT.index(b)) % 26]
+
+The ACA convention writes the indicator key under plaintext ``A``. Kryptos
+K1/K2 are exactly Quagmire III with the KRYPTOS-keyed alphabet and the
+indicator base at the alphabet's *first* letter (``K``), which reduces the
+offset to ``PT.index(P) + PT.index(k)`` — the form implemented in
+``kryptos.ciphers.vigenere_decrypt``. ``indicator_base=None`` selects that
+first-letter convention; pass ``"A"`` for strict ACA behaviour.
+"""
+
+from __future__ import annotations
+
+STANDARD_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def keyword_alphabet(keyword: str, base: str = STANDARD_ALPHABET) -> str:
+    """Build a keyword-mixed alphabet: unique keyword letters, then the rest.
+
+    ``keyword_alphabet("KRYPTOS")`` -> ``"KRYPTOSABCDEFGHIJLMNQUVWXZ"``.
+    """
+    seen: list[str] = []
+    for ch in keyword.upper() + base:
+        if ch in base and ch not in seen:
+            seen.append(ch)
+    return "".join(seen)
+
+
+def _clean(text: str, alphabet: str) -> str:
+    return "".join(c for c in text.upper() if c in alphabet)
+
+
+def _crypt(
+    text: str,
+    indicator_key: str,
+    pt_alphabet: str,
+    ct_alphabet: str,
+    indicator_base: str | None,
+    decrypt: bool,
+) -> str:
+    if len(pt_alphabet) != len(ct_alphabet):
+        raise ValueError("Plaintext and ciphertext alphabets must be the same length")
+    n = len(pt_alphabet)
+    base = pt_alphabet[0] if indicator_base is None else indicator_base.upper()
+    base_idx = pt_alphabet.index(base)
+
+    key = _clean(indicator_key, ct_alphabet)
+    if not key:
+        raise ValueError("Indicator key must contain at least one alphabet character")
+    key_offsets = [ct_alphabet.index(k) - base_idx for k in key]
+
+    src, dst = (ct_alphabet, pt_alphabet) if decrypt else (pt_alphabet, ct_alphabet)
+    sign = -1 if decrypt else 1
+    chars = _clean(text, src)
+    return "".join(dst[(src.index(c) + sign * key_offsets[i % len(key_offsets)]) % n] for i, c in enumerate(chars))
+
+
+def quagmire1_encrypt(plaintext: str, key: str, alphabet_keyword: str, indicator_base: str | None = None) -> str:
+    """Quagmire I: keyed plaintext alphabet, straight ciphertext alphabet."""
+    return _crypt(plaintext, key, keyword_alphabet(alphabet_keyword), STANDARD_ALPHABET, indicator_base, False)
+
+
+def quagmire1_decrypt(ciphertext: str, key: str, alphabet_keyword: str, indicator_base: str | None = None) -> str:
+    return _crypt(ciphertext, key, keyword_alphabet(alphabet_keyword), STANDARD_ALPHABET, indicator_base, True)
+
+
+def quagmire2_encrypt(plaintext: str, key: str, alphabet_keyword: str, indicator_base: str | None = None) -> str:
+    """Quagmire II: straight plaintext alphabet, keyed ciphertext alphabet."""
+    return _crypt(plaintext, key, STANDARD_ALPHABET, keyword_alphabet(alphabet_keyword), indicator_base, False)
+
+
+def quagmire2_decrypt(ciphertext: str, key: str, alphabet_keyword: str, indicator_base: str | None = None) -> str:
+    return _crypt(ciphertext, key, STANDARD_ALPHABET, keyword_alphabet(alphabet_keyword), indicator_base, True)
+
+
+def quagmire3_encrypt(plaintext: str, key: str, alphabet_keyword: str, indicator_base: str | None = None) -> str:
+    """Quagmire III: the same keyed alphabet on both sides (Kryptos K1/K2 form)."""
+    keyed = keyword_alphabet(alphabet_keyword)
+    return _crypt(plaintext, key, keyed, keyed, indicator_base, False)
+
+
+def quagmire3_decrypt(ciphertext: str, key: str, alphabet_keyword: str, indicator_base: str | None = None) -> str:
+    keyed = keyword_alphabet(alphabet_keyword)
+    return _crypt(ciphertext, key, keyed, keyed, indicator_base, True)
+
+
+def quagmire4_encrypt(
+    plaintext: str,
+    key: str,
+    pt_keyword: str,
+    ct_keyword: str,
+    indicator_base: str | None = None,
+) -> str:
+    """Quagmire IV: different keyed alphabets for plaintext and ciphertext."""
+    return _crypt(plaintext, key, keyword_alphabet(pt_keyword), keyword_alphabet(ct_keyword), indicator_base, False)
+
+
+def quagmire4_decrypt(
+    ciphertext: str,
+    key: str,
+    pt_keyword: str,
+    ct_keyword: str,
+    indicator_base: str | None = None,
+) -> str:
+    return _crypt(ciphertext, key, keyword_alphabet(pt_keyword), keyword_alphabet(ct_keyword), indicator_base, True)
+
+
+__all__ = [
+    "STANDARD_ALPHABET",
+    "keyword_alphabet",
+    "quagmire1_encrypt",
+    "quagmire1_decrypt",
+    "quagmire2_encrypt",
+    "quagmire2_decrypt",
+    "quagmire3_encrypt",
+    "quagmire3_decrypt",
+    "quagmire4_encrypt",
+    "quagmire4_decrypt",
+]

--- a/src/kryptos/k4/quagmire_sweep.py
+++ b/src/kryptos/k4/quagmire_sweep.py
@@ -1,0 +1,232 @@
+"""Systematic Quagmire I-IV sweep against K4.
+
+The leading K4 hypothesis is a product cipher whose substitution layer is a
+Quagmire III (the same KRYPTOS-keyed tableau Sanborn used for K1/K2). This
+sweep tests all four Quagmire variants against K4 directly with:
+
+- word indicator keys (KRYPTOS, PALIMPSEST, ABSCISSA, BERLIN, CLOCK, ...)
+- Berlin Clock derived indicator keys (one per minute-of-day state, mapping
+  the lamp-row values [5h, 1h, 5m, 1m, sec] to tableau letters)
+- both indicator-base conventions (Kryptos first-letter and ACA ``A``)
+
+Candidates are gated on the four confirmed positional cribs (EAST@22,
+NORTHEAST@26, BERLIN@63, CLOCK@69). A null-result artifact is always written
+so the run is fully provenance-tracked; >=3 positional cribs or >=4 keywords
+anywhere raises EurekaSignal with a breakthrough snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, time, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from .berlin_clock import berlin_clock_shifts
+from .eureka import DEFAULT_SNAPSHOT_PATH, EurekaSignal, write_breakthrough_snapshot
+from .keystream_validator import K4_CRIBS
+from .quagmire import keyword_alphabet, quagmire1_decrypt, quagmire2_decrypt, quagmire3_decrypt, quagmire4_decrypt
+
+K4 = "OBKRUOXOGHULBSOLIFBBWFLRVQQPRNGKSSOTWTQSJQSSEKZZWATJKLUDIAWINFBNYPVTTMZFPKWGDKZXTJCDIGKUHUAUEKCAR"
+
+WORD_KEYS = [
+    "KRYPTOS",
+    "PALIMPSEST",
+    "ABSCISSA",
+    "BERLIN",
+    "CLOCK",
+    "BERLINCLOCK",
+    "NORTHEAST",
+    "EAST",
+    "SANBORN",
+    "LANGLEY",
+]
+
+ALPHABET_KEYWORDS = ["KRYPTOS", "BERLIN", "CLOCK", "BERLINCLOCK"]
+
+_EUREKA_WORDS = frozenset({"EAST", "NORTHEAST", "BERLIN", "CLOCK"})
+
+
+def _keyword_hits(text: str) -> int:
+    upper = text.upper()
+    return sum(1 for w in _EUREKA_WORDS if w in upper)
+
+
+def positional_crib_hits(candidate: str) -> int:
+    """Count confirmed K4 cribs matched at their exact positions."""
+    hits = 0
+    for word, start in K4_CRIBS.values():
+        if candidate[start : start + len(word)] == word:  # noqa: E203
+            hits += 1
+    return hits
+
+
+def clock_indicator_keys(alphabet: str, include_seconds: bool = False) -> dict[str, str]:
+    """Berlin Clock indicator keys: one per minute-of-day state.
+
+    Maps each lamp-row count [5h, 1h, 5m, 1m(, sec)] to the letter at that
+    index in ``alphabet``, giving a 4- or 5-letter periodic indicator key.
+
+    Returns:
+        Dict of "HH:MM" -> key string (deduplicated by key downstream).
+    """
+    keys: dict[str, str] = {}
+    for hour in range(24):
+        for minute in range(60):
+            shifts = berlin_clock_shifts(time(hour, minute, 0))
+            values = shifts if include_seconds else shifts[:4]
+            keys[f"{hour:02d}:{minute:02d}"] = "".join(alphabet[v] for v in values)
+    return keys
+
+
+def _variant_decryptors() -> dict[str, Callable[[str, str, str, str | None], str]]:
+    return {
+        "quagmire1": quagmire1_decrypt,
+        "quagmire2": quagmire2_decrypt,
+        "quagmire3": quagmire3_decrypt,
+    }
+
+
+def run_quagmire_sweep(
+    ciphertext: str = K4,
+    word_keys: list[str] | None = None,
+    alphabet_keywords: list[str] | None = None,
+    eureka_snapshot_path: str | Path = DEFAULT_SNAPSHOT_PATH,
+    null_artifact_path: str | Path = "K4_QUAGMIRE_NULL.json",
+    positional_eureka_threshold: int = 3,
+    keyword_eureka_threshold: int = 4,
+) -> dict[str, Any]:
+    """Sweep Quagmire I-IV against K4 with word and Berlin Clock indicator keys.
+
+    Returns a summary dict (status, run_params, best_candidates) and writes it
+    to ``null_artifact_path``. Raises EurekaSignal on a crib breakthrough.
+    """
+    if word_keys is None:
+        word_keys = WORD_KEYS
+    if alphabet_keywords is None:
+        alphabet_keywords = ALPHABET_KEYWORDS
+
+    ct = "".join(c for c in ciphertext.upper() if c.isalpha())
+    ts_start = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    total_tested = 0
+    best_candidates: list[dict[str, Any]] = []
+
+    def _evaluate(candidate: str, info: dict[str, Any]) -> None:
+        nonlocal total_tested
+        total_tested += 1
+        pos_hits = positional_crib_hits(candidate)
+        kw_hits = _keyword_hits(candidate)
+
+        if pos_hits >= positional_eureka_threshold or kw_hits >= keyword_eureka_threshold:
+            key_info = {"attack": "quagmire_sweep", **info}
+            snap = write_breakthrough_snapshot(
+                candidate,
+                key_info,
+                extra={"positional_crib_hits": pos_hits, "keyword_hits": kw_hits, "sweep_ts": ts_start},
+                path=eureka_snapshot_path,
+            )
+            raise EurekaSignal(
+                snapshot_path=snap,
+                result={
+                    "candidate_text": candidate,
+                    "key_info": key_info,
+                    "snapshot_path": snap,
+                    "positional_crib_hits": pos_hits,
+                    "keyword_hits": kw_hits,
+                },
+            )
+
+        if pos_hits > 0 or kw_hits > 0:
+            best_candidates.append(
+                {
+                    "candidate_text": candidate,
+                    "positional_crib_hits": pos_hits,
+                    "keyword_hits": kw_hits,
+                    **info,
+                }
+            )
+
+    bases: list[str | None] = [None, "A"]  # Kryptos first-letter and ACA conventions
+
+    # --- Quagmire I-III: word keys x alphabet keywords x indicator bases ---
+    for variant, decryptor in _variant_decryptors().items():
+        for alpha_kw in alphabet_keywords:
+            for key in word_keys:
+                for base in bases:
+                    candidate = decryptor(ct, key, alpha_kw, base)
+                    _evaluate(
+                        candidate,
+                        {"variant": variant, "key": key, "alphabet_keyword": alpha_kw, "indicator_base": base},
+                    )
+
+    # --- Quagmire IV: ordered pairs of distinct alphabet keywords ---
+    for pt_kw in alphabet_keywords:
+        for ct_kw in alphabet_keywords:
+            if pt_kw == ct_kw:
+                continue
+            for key in word_keys:
+                for base in bases:
+                    candidate = quagmire4_decrypt(ct, key, pt_kw, ct_kw, base)
+                    _evaluate(
+                        candidate,
+                        {
+                            "variant": "quagmire4",
+                            "key": key,
+                            "pt_keyword": pt_kw,
+                            "ct_keyword": ct_kw,
+                            "indicator_base": base,
+                        },
+                    )
+
+    # --- Quagmire III with Berlin Clock indicator keys (KRYPTOS tableau) ---
+    clock_alphabet = keyword_alphabet("KRYPTOS")
+    for include_seconds in (False, True):
+        seen_keys: set[str] = set()
+        for clock_time, key in clock_indicator_keys(clock_alphabet, include_seconds).items():
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            for base in bases:
+                candidate = quagmire3_decrypt(ct, key, "KRYPTOS", base)
+                _evaluate(
+                    candidate,
+                    {
+                        "variant": "quagmire3_clock",
+                        "key": key,
+                        "clock_time": clock_time,
+                        "include_seconds": include_seconds,
+                        "alphabet_keyword": "KRYPTOS",
+                        "indicator_base": base,
+                    },
+                )
+
+    best_candidates.sort(key=lambda r: (-r["positional_crib_hits"], -r["keyword_hits"]))
+
+    summary: dict[str, Any] = {
+        "status": "null_result",
+        "attack": "quagmire_sweep",
+        "timestamp": ts_start,
+        "run_params": {
+            "word_keys": word_keys,
+            "alphabet_keywords": alphabet_keywords,
+            "total_tested": total_tested,
+            "positional_eureka_threshold": positional_eureka_threshold,
+            "keyword_eureka_threshold": keyword_eureka_threshold,
+            "ts_start": ts_start,
+        },
+        "best_candidates": best_candidates[:10],
+        "null_artifact_path": str(Path(null_artifact_path).resolve()),
+    }
+    Path(null_artifact_path).write_text(json.dumps(summary, indent=2, default=str), encoding="utf-8")
+    return summary
+
+
+__all__ = [
+    "K4",
+    "WORD_KEYS",
+    "ALPHABET_KEYWORDS",
+    "positional_crib_hits",
+    "clock_indicator_keys",
+    "run_quagmire_sweep",
+]

--- a/tests/functional/test_quagmire.py
+++ b/tests/functional/test_quagmire.py
@@ -1,0 +1,177 @@
+"""Tests for kryptos.k4.quagmire and quagmire_sweep."""
+
+from __future__ import annotations
+
+import json
+import random
+import string
+
+import pytest
+
+from kryptos.ciphers import vigenere_decrypt
+from kryptos.k4.eureka import EurekaSignal
+from kryptos.k4.quagmire import (
+    keyword_alphabet,
+    quagmire1_decrypt,
+    quagmire1_encrypt,
+    quagmire2_decrypt,
+    quagmire2_encrypt,
+    quagmire3_decrypt,
+    quagmire3_encrypt,
+    quagmire4_decrypt,
+    quagmire4_encrypt,
+)
+from kryptos.k4.quagmire_sweep import K4, clock_indicator_keys, positional_crib_hits, run_quagmire_sweep
+
+# Verified K1/K2 ground truth (tests/smoke/test_k1_k2_k3_reliability.py)
+K1_CIPHERTEXT = "EMUFPHZLRFAXYUSDJKZLDKRNSHGNFIVJYQTQUXQBQVYUVLLTREVJYQTMKYRDMFD"
+K1_KEY = "PALIMPSEST"
+K1_PLAINTEXT = "BETWEENSUBTLESHADINGANDTHEABSENCEOFLIGHTLIESTHENUANCEOFIQLUSION"
+
+K2_CIPHERTEXT = (
+    "VFPJUDEEHZWETZYVGWHKKQETGFQJNCEGGWHKKDQMCPFQZDQMMIAGPFXHQRLGTIM"
+    "VMZJANQLVKQEDAGDVFRPJUNGEUNAQZGZLECGYUXUEENJTBJLBQCRTBJDFHRRYIZE"
+    "TKZEMVDUFKSJHKFWHKUWQLSZFTIHHDDDUVHDWKBFUFPWNTDFIYCUQZEREEVLDKFE"
+    "ZMOQQJLTTUGSYQPFEUNLAVIDXFLGGTEZFKZBSFDQVGOGIPUFXHHDRKFFHQNTGPUA"
+    "ECNUVPDJMQCLQUMUNEDFQELZZVRRGKFFVOEEXBDMVPNFQXEZLGREDNQFCHOBSSPH"
+    "FLLOXQRZXGZQAAVTTEXOLIQQTIVWHHMQAUQZMASMRVLQJNWB"
+)
+K2_KEY = "ABSCISSA"
+
+
+class TestKeywordAlphabet:
+    def test_kryptos_alphabet(self):
+        assert keyword_alphabet("KRYPTOS") == "KRYPTOSABCDEFGHIJLMNQUVWXZ"
+
+    def test_empty_keyword_is_standard(self):
+        assert keyword_alphabet("") == string.ascii_uppercase
+
+    def test_repeated_letters_deduplicated(self):
+        assert keyword_alphabet("BERLINBERLIN").startswith("BERLIN")
+        assert len(keyword_alphabet("BERLINBERLIN")) == 26
+
+
+class TestKryptosGroundTruth:
+    """Quagmire III with the KRYPTOS tableau must exactly reproduce K1/K2."""
+
+    def test_k1_decrypt(self):
+        assert quagmire3_decrypt(K1_CIPHERTEXT, K1_KEY, "KRYPTOS") == K1_PLAINTEXT
+
+    def test_k1_encrypt(self):
+        assert quagmire3_encrypt(K1_PLAINTEXT, K1_KEY, "KRYPTOS") == K1_CIPHERTEXT
+
+    def test_k2_matches_canonical_vigenere(self):
+        expected = vigenere_decrypt(K2_CIPHERTEXT, K2_KEY)
+        assert quagmire3_decrypt(K2_CIPHERTEXT, K2_KEY, "KRYPTOS") == expected
+
+    def test_k2_round_trip(self):
+        plaintext = quagmire3_decrypt(K2_CIPHERTEXT, K2_KEY, "KRYPTOS")
+        assert quagmire3_encrypt(plaintext, K2_KEY, "KRYPTOS") == K2_CIPHERTEXT
+
+
+class TestVigenereReduction:
+    def test_straight_alphabets_reduce_to_classic_vigenere(self):
+        # Quagmire with straight alphabets and ACA base 'A' is plain Vigenere
+        assert quagmire3_encrypt("ATTACKATDAWN", "LEMON", "", "A") == "LXFOPVEFRNHR"
+        assert quagmire3_decrypt("LXFOPVEFRNHR", "LEMON", "", "A") == "ATTACKATDAWN"
+
+
+class TestRoundTrips:
+    @pytest.mark.parametrize("variant", ["q1", "q2", "q3"])
+    def test_round_trip(self, variant):
+        encrypt, decrypt = {
+            "q1": (quagmire1_encrypt, quagmire1_decrypt),
+            "q2": (quagmire2_encrypt, quagmire2_decrypt),
+            "q3": (quagmire3_encrypt, quagmire3_decrypt),
+        }[variant]
+        rng = random.Random(99)
+        for _ in range(5):
+            plaintext = "".join(rng.choices(string.ascii_uppercase, k=60))
+            for base in (None, "A"):
+                ct = encrypt(plaintext, "SPRINGFIELD", "FLOWER", base)
+                assert decrypt(ct, "SPRINGFIELD", "FLOWER", base) == plaintext
+
+    def test_q4_round_trip(self):
+        rng = random.Random(7)
+        plaintext = "".join(rng.choices(string.ascii_uppercase, k=60))
+        for base in (None, "A"):
+            ct = quagmire4_encrypt(plaintext, "GRONSFELD", "PAINT", "BRUSH", base)
+            assert quagmire4_decrypt(ct, "GRONSFELD", "PAINT", "BRUSH", base) == plaintext
+
+    def test_variants_disagree(self):
+        """Sanity: keyed alphabets actually change the output per variant."""
+        plaintext = "THEQUICKBROWNFOXJUMPSOVERTHELAZYDOG"
+        outputs = {
+            quagmire1_encrypt(plaintext, "KEY", "KRYPTOS"),
+            quagmire2_encrypt(plaintext, "KEY", "KRYPTOS"),
+            quagmire3_encrypt(plaintext, "KEY", "KRYPTOS"),
+            quagmire4_encrypt(plaintext, "KEY", "KRYPTOS", "BERLIN"),
+        }
+        assert len(outputs) == 4
+
+    def test_invalid_key_raises(self):
+        with pytest.raises(ValueError, match="Indicator key"):
+            quagmire3_encrypt("ABC", "123", "KRYPTOS")
+
+
+class TestPositionalCribHits:
+    def test_full_match(self):
+        plaintext = list("X" * 97)
+        plaintext[22:26] = "EAST"
+        plaintext[26:35] = "NORTHEAST"
+        plaintext[63:69] = "BERLIN"
+        plaintext[69:74] = "CLOCK"
+        assert positional_crib_hits("".join(plaintext)) == 4
+
+    def test_no_match(self):
+        assert positional_crib_hits("X" * 97) == 0
+
+
+class TestClockIndicatorKeys:
+    def test_minute_states(self):
+        keys = clock_indicator_keys(keyword_alphabet("KRYPTOS"))
+        assert len(keys) == 1440
+        # 17:00 -> rows [3, 2, 0, 0] -> KRYPTOS-alphabet letters P, Y, K, K
+        assert keys["17:00"] == "PYKK"
+        assert all(len(k) == 4 for k in keys.values())
+
+    def test_with_seconds(self):
+        keys = clock_indicator_keys(keyword_alphabet("KRYPTOS"), include_seconds=True)
+        assert all(len(k) == 5 for k in keys.values())
+
+
+class TestQuagmireSweep:
+    def test_null_result_artifact(self, tmp_path):
+        artifact = tmp_path / "null.json"
+        summary = run_quagmire_sweep(
+            word_keys=["KRYPTOS", "BERLIN"],
+            alphabet_keywords=["KRYPTOS"],
+            null_artifact_path=artifact,
+            eureka_snapshot_path=tmp_path / "snap.md",
+        )
+        assert summary["status"] == "null_result"
+        assert summary["run_params"]["total_tested"] > 0
+        data = json.loads(artifact.read_text(encoding="utf-8"))
+        assert data["attack"] == "quagmire_sweep"
+
+    def test_eureka_on_planted_solution(self, tmp_path):
+        plaintext = list("A" * 97)
+        plaintext[22:26] = "EAST"
+        plaintext[26:35] = "NORTHEAST"
+        plaintext[63:69] = "BERLIN"
+        plaintext[69:74] = "CLOCK"
+        planted_ct = quagmire3_encrypt("".join(plaintext), "BERLIN", "KRYPTOS")
+
+        with pytest.raises(EurekaSignal) as excinfo:
+            run_quagmire_sweep(
+                ciphertext=planted_ct,
+                word_keys=["BERLIN"],
+                alphabet_keywords=["KRYPTOS"],
+                null_artifact_path=tmp_path / "null.json",
+                eureka_snapshot_path=tmp_path / "snap.md",
+            )
+        assert excinfo.value.result["positional_crib_hits"] == 4
+
+    def test_k4_default_ciphertext_is_canonical(self):
+        assert len(K4) == 97
+        assert K4.startswith("OBKR")


### PR DESCRIPTION
## Summary
- **`kryptos.k4.quagmire`** — canonical encrypt/decrypt for the ACA Quagmire I–IV family via one shared core, with both indicator-base conventions (Kryptos first-letter and ACA `A`). This was the biggest gap in the substitution toolbox: Quagmire III is the consensus hypothesis for K4's substitution layer, and K1/K2 *are* Quagmire III on the KRYPTOS tableau.
- **Ground-truth verification**: `quagmire3_decrypt`/`_encrypt` with the KRYPTOS alphabet exactly reproduce K1 (PALIMPSEST) and K2 (ABSCISSA) ciphertext↔plaintext, and the straight-alphabet case reduces to classic Vigenère (LEMON/ATTACKATDAWN test vector).
- **`kryptos.k4.quagmire_sweep.run_quagmire_sweep`** — 6,240 combinations against K4: Q1/Q2/Q3 × 4 alphabet keywords × 10 word keys × 2 indicator bases, Q4 ordered keyword pairs, plus Q3 with 1,440 Berlin Clock minute-state indicator keys on the KRYPTOS tableau. Candidates gated on the four confirmed positional cribs (EAST@22, NORTHEAST@26, BERLIN@63, CLOCK@69) with the EurekaSignal breakthrough protocol and an always-written null-result artifact.

## Research result
**NULL RESULT** — zero positional crib or keyword hits across all 6,240 combinations. Rules out pure single-layer Quagmire (any variant, these keys/alphabets), reinforcing the substitution+transposition composite model. Recorded in `docs/analysis/K4_ACTIVE_RESEARCH.md` (Ruled Out + Infrastructure tables) and `TASKS.md`.

## Test plan
- [x] 21 new tests in `tests/functional/test_quagmire.py`: K1/K2 ground-truth reproduction, Vigenère reduction, round-trips for all 4 variants × both bases, clock indicator key generation (1,440 states, spot-checked 17:00→PYKK), sweep null-artifact path, and a planted-solution EurekaSignal path — all pass in Docker
- [x] Full suite in Docker: 948 passed (same 6 known bind-mount environment artifacts as main, pass in CI)
- [x] Real sweep executed against K4 in Docker: `status: null_result`, `total_tested: 6240`

🤖 Generated with [Claude Code](https://claude.com/claude-code)