### PR TITLE
feat: persist campaign runs + candidates to Neon (best-effort)

### DIFF
--- a/docs/reference/AGENTS_ARCHITECTURE.md
+++ b/docs/reference/AGENTS_ARCHITECTURE.md
@@ -105,6 +105,11 @@ Strategy knowledge (`strategy_kb` table) is read by `OpsStrategicDirector` on in
 - **DB writes** require `DATABASE_URL` in environment (see `kryptos.db`). Tables are
   defined in `kryptos.db_schema` and created idempotently with `kryptos db-init`
   (`strategy_kb`, `ops_decisions`, `discovered_cribs`, `campaign_runs`, `candidates`).
+  Write paths: agents persist `strategy_kb`/`ops_decisions` (`ops_director`) and
+  `discovered_cribs` (`spy_web_intel`); candidate reporting persists `campaign_runs` +
+  `candidates` via `kryptos.persistence` (best-effort, mirrors the JSON/CSV artifacts,
+  auto-enabled when `DATABASE_URL` is set). All write paths fall back to files on any
+  DB error so persistence is never on the critical path.
 
 ---
 

--- a/src/kryptos/k4/reporting.py
+++ b/src/kryptos/k4/reporting.py
@@ -21,8 +21,8 @@ def _ensure_dir(path: str) -> None:
 
 
 def _key_hash(key: Sequence[Sequence[int]]) -> str:
-    flat = ','.join(str(v) for row in key for v in row)
-    return hashlib.sha1(flat.encode('utf-8')).hexdigest()[:16]
+    flat = ",".join(str(v) for row in key for v in row)
+    return hashlib.sha1(flat.encode("utf-8")).hexdigest()[:16]
 
 
 def write_candidates_json(
@@ -37,38 +37,38 @@ def write_candidates_json(
     """Write detailed candidate list (limited) to JSON. Returns path."""
     if output_path is None:
         base = ensure_reports_dir()
-        output_path = str(base / 'k4_candidates.json')
-    _ensure_dir(os.path.dirname(output_path) or '.')
-    ranked = sorted(candidates, key=lambda c: c.get('score', 0.0), reverse=True)[:limit]
+        output_path = str(base / "k4_candidates.json")
+    _ensure_dir(os.path.dirname(output_path) or ".")
+    ranked = sorted(candidates, key=lambda c: c.get("score", 0.0), reverse=True)[:limit]
     enriched = []
     for rank, cand in enumerate(ranked, start=1):
-        text = cand.get('text', '')
+        text = cand.get("text", "")
         metrics = baseline_stats(text)
-        key = cand.get('key')
+        key = cand.get("key")
         enriched.append(
             {
-                'rank': rank,
-                'score': cand.get('score'),
-                'source': cand.get('source'),
-                'key': key,
-                'key_hash': _key_hash(key) if key else None,
-                'text': text,
-                'metrics': metrics,
-                'origin_stage': stage,
-                'candidate_lineage': cand.get('lineage') or lineage,
-                'trace': cand.get('trace'),
+                "rank": rank,
+                "score": cand.get("score"),
+                "source": cand.get("source"),
+                "key": key,
+                "key_hash": _key_hash(key) if key else None,
+                "text": text,
+                "metrics": metrics,
+                "origin_stage": stage,
+                "candidate_lineage": cand.get("lineage") or lineage,
+                "trace": cand.get("trace"),
             },
         )
     payload = {
-        'cipher': cipher_label,
-        'stage': stage,
-        'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
-        'ciphertext_prefix': ciphertext[:50],
-        'candidate_count': len(enriched),
-        'lineage': lineage,
-        'candidates': enriched,
+        "cipher": cipher_label,
+        "stage": stage,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "ciphertext_prefix": ciphertext[:50],
+        "candidate_count": len(enriched),
+        "lineage": lineage,
+        "candidates": enriched,
     }
-    with open(output_path, 'w', encoding='utf-8') as fh:
+    with open(output_path, "w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2)
     return output_path
 
@@ -81,21 +81,21 @@ def write_candidates_csv(
     """Write summary CSV: rank, score, source, key_hash, text_prefix. Returns path."""
     if output_path is None:
         base = ensure_reports_dir()
-        output_path = str(base / 'k4_candidates.csv')
-    _ensure_dir(os.path.dirname(output_path) or '.')
-    ranked = sorted(candidates, key=lambda c: c.get('score', 0.0), reverse=True)[:limit]
-    with open(output_path, 'w', newline='', encoding='utf-8') as fh:
+        output_path = str(base / "k4_candidates.csv")
+    _ensure_dir(os.path.dirname(output_path) or ".")
+    ranked = sorted(candidates, key=lambda c: c.get("score", 0.0), reverse=True)[:limit]
+    with open(output_path, "w", newline="", encoding="utf-8") as fh:
         w = csv.writer(fh)
-        w.writerow(['rank', 'score', 'source', 'key_hash', 'text_prefix'])
+        w.writerow(["rank", "score", "source", "key_hash", "text_prefix"])
         for rank, cand in enumerate(ranked, start=1):
-            key = cand.get('key')
+            key = cand.get("key")
             w.writerow(
                 [
                     rank,
-                    cand.get('score'),
-                    cand.get('source'),
-                    _key_hash(key) if key else '',
-                    (cand.get('text', '')[:60]),
+                    cand.get("score"),
+                    cand.get("source"),
+                    _key_hash(key) if key else "",
+                    (cand.get("text", "")[:60]),
                 ],
             )
     return output_path
@@ -110,19 +110,34 @@ def generate_candidate_artifacts(
     limit: int = 50,
     write_csv: bool = True,
     lineage: list[str] | None = None,
+    persist_db: bool | None = None,
 ) -> dict[str, str]:
-    """Generate JSON (and optionally CSV) artifacts; return dict of paths."""
+    """Generate JSON (and optionally CSV) artifacts; return dict of paths.
+
+    When ``persist_db`` is ``None`` (the default) the candidates are also
+    mirrored to Neon if ``DATABASE_URL`` is configured; pass ``True``/``False``
+    to force or skip that. DB persistence is best-effort and never affects the
+    file artifacts. If a run is persisted, its id is returned under the
+    ``'db_run_id'`` key.
+    """
     if out_dir is None:
         out_dir = str(ensure_reports_dir())
     _ensure_dir(out_dir)
-    json_path = os.path.join(out_dir, 'k4_candidates.json')
+    json_path = os.path.join(out_dir, "k4_candidates.json")
     paths = {
-        'json': write_candidates_json(stage, cipher_label, ciphertext, candidates, json_path, limit, lineage=lineage),
+        "json": write_candidates_json(stage, cipher_label, ciphertext, candidates, json_path, limit, lineage=lineage),
     }
     if write_csv:
-        csv_path = os.path.join(out_dir, 'k4_candidates.csv')
-        paths['csv'] = write_candidates_csv(candidates, csv_path, limit)
+        csv_path = os.path.join(out_dir, "k4_candidates.csv")
+        paths["csv"] = write_candidates_csv(candidates, csv_path, limit)
+
+    from ..persistence import db_enabled, persist_campaign_candidates
+
+    if persist_db or (persist_db is None and db_enabled()):
+        run_id = persist_campaign_candidates(stage, cipher_label, ciphertext, candidates, limit, lineage=lineage)
+        if run_id is not None:
+            paths["db_run_id"] = str(run_id)
     return paths
 
 
-__all__ = ['write_candidates_json', 'write_candidates_csv', 'generate_candidate_artifacts']
+__all__ = ["write_candidates_json", "write_candidates_csv", "generate_candidate_artifacts"]

--- a/src/kryptos/persistence.py
+++ b/src/kryptos/persistence.py
@@ -1,0 +1,159 @@
+"""Best-effort persistence of campaign runs and candidates to Neon/Postgres.
+
+The ``campaign_runs`` and ``candidates`` tables (see ``kryptos.db_schema``)
+exist but, until now, nothing populated them — candidate output lived only in
+the JSON/CSV artifacts under ``artifacts/``. This module mirrors that output
+into Neon when ``DATABASE_URL`` is configured, so the API/dashboard layer has
+queryable run history.
+
+Every function here is best-effort: a missing ``DATABASE_URL``, an absent
+``psycopg2``, or any database error is swallowed (logged at WARNING) and the
+caller's file-based flow is unaffected. Persistence is never on the critical
+path of a cryptanalysis run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from collections.abc import Sequence
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _key_hash(key: Sequence[Sequence[int]]) -> str:
+    flat = ",".join(str(v) for row in key for v in row)
+    return hashlib.sha1(flat.encode("utf-8")).hexdigest()[:16]
+
+
+def db_enabled() -> bool:
+    """True when a DATABASE_URL is configured (DB persistence is possible)."""
+    return bool(os.getenv("DATABASE_URL"))
+
+
+def persist_campaign_candidates(
+    stage: str,
+    cipher_label: str,
+    ciphertext: str,
+    candidates: list[dict[str, Any]],
+    limit: int = 50,
+    lineage: list[str] | None = None,
+    status: str = "complete",
+    metadata: dict[str, Any] | None = None,
+) -> int | None:
+    """Record a campaign run and its top candidates in Neon.
+
+    Creates one ``campaign_runs`` row and inserts up to ``limit`` ranked
+    ``candidates`` rows referencing it. Returns the new ``campaign_runs.id``,
+    or ``None`` if persistence was skipped (no DATABASE_URL) or failed.
+
+    Args mirror ``kryptos.k4.reporting.write_candidates_json`` so call sites
+    can persist the same data they already write to disk.
+    """
+    if not db_enabled():
+        return None
+
+    try:
+        from kryptos.db import get_conn
+    except ImportError as exc:  # pragma: no cover - defensive
+        logger.warning("DB persistence unavailable (%s); skipping", exc)
+        return None
+
+    ranked = sorted(candidates, key=lambda c: c.get("score", 0.0), reverse=True)[:limit]
+
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO campaign_runs (label, stage, cipher_label, ciphertext, status, metadata)"
+                    " VALUES (%s, %s, %s, %s, %s, %s::jsonb) RETURNING id",
+                    (
+                        cipher_label,
+                        stage,
+                        cipher_label,
+                        ciphertext[:500],
+                        status,
+                        json.dumps(metadata or {}),
+                    ),
+                )
+                run_id = cur.fetchone()[0]
+
+                for rank, cand in enumerate(ranked, start=1):
+                    key = cand.get("key")
+                    cur.execute(
+                        "INSERT INTO candidates"
+                        " (campaign_run_id, rank, score, source, key, key_hash, text, metrics, origin_stage, lineage)"
+                        " VALUES (%s, %s, %s, %s, %s::jsonb, %s, %s, %s::jsonb, %s, %s::jsonb)",
+                        (
+                            run_id,
+                            rank,
+                            cand.get("score"),
+                            cand.get("source"),
+                            json.dumps(key) if key is not None else None,
+                            _key_hash(key) if key else None,
+                            cand.get("text", ""),
+                            json.dumps(cand.get("metrics", {})),
+                            stage,
+                            json.dumps(cand.get("lineage") or lineage),
+                        ),
+                    )
+        logger.info("Persisted campaign run %s with %d candidates to Neon", run_id, len(ranked))
+        return int(run_id)
+    except Exception as exc:  # noqa: BLE001 - persistence must never break a run
+        logger.warning("Failed to persist campaign candidates to DB (%s); file artifacts unaffected", exc)
+        return None
+
+
+def fetch_recent_runs(limit: int = 20) -> list[dict[str, Any]]:
+    """Return recent campaign runs (newest first). Empty list if DB disabled."""
+    if not db_enabled():
+        return []
+    try:
+        from kryptos.db import get_conn
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id, label, stage, cipher_label, status, started_at, finished_at"
+                    " FROM campaign_runs ORDER BY id DESC LIMIT %s",
+                    (limit,),
+                )
+                rows = cur.fetchall()
+        cols = ["id", "label", "stage", "cipher_label", "status", "started_at", "finished_at"]
+        return [dict(zip(cols, row)) for row in rows]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to fetch campaign runs (%s)", exc)
+        return []
+
+
+def fetch_run_candidates(run_id: int, limit: int = 50) -> list[dict[str, Any]]:
+    """Return a run's candidates ordered by rank. Empty list if DB disabled."""
+    if not db_enabled():
+        return []
+    try:
+        from kryptos.db import get_conn
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT rank, score, source, key, key_hash, text, metrics, origin_stage, lineage"
+                    " FROM candidates WHERE campaign_run_id = %s ORDER BY rank LIMIT %s",
+                    (run_id, limit),
+                )
+                rows = cur.fetchall()
+        cols = ["rank", "score", "source", "key", "key_hash", "text", "metrics", "origin_stage", "lineage"]
+        return [dict(zip(cols, row)) for row in rows]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to fetch candidates for run %s (%s)", run_id, exc)
+        return []
+
+
+__all__ = [
+    "db_enabled",
+    "persist_campaign_candidates",
+    "fetch_recent_runs",
+    "fetch_run_candidates",
+]

--- a/tests/functional/test_persistence.py
+++ b/tests/functional/test_persistence.py
@@ -1,0 +1,99 @@
+"""Tests for kryptos.persistence — best-effort Neon candidate/run storage."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from kryptos.persistence import db_enabled, fetch_recent_runs, fetch_run_candidates, persist_campaign_candidates
+
+SAMPLE_CANDIDATES = [
+    {"score": -10.0, "source": "quagmire", "key": [[1, 2], [3, 4]], "text": "EASTNORTHEAST", "metrics": {"ic": 0.06}},
+    {"score": -25.0, "source": "beaufort", "key": None, "text": "GARBLEDTEXTHERE", "metrics": {}},
+]
+
+
+class TestDbDisabled:
+    def test_db_enabled_false_without_url(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        assert db_enabled() is False
+
+    def test_persist_returns_none_without_url(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        assert persist_campaign_candidates("stage1", "K4", "OBKR...", SAMPLE_CANDIDATES) is None
+
+    def test_fetch_helpers_empty_without_url(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        assert fetch_recent_runs() == []
+        assert fetch_run_candidates(1) == []
+
+
+class TestReportingIntegration:
+    def test_generate_artifacts_skips_db_when_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        from kryptos.k4.reporting import generate_candidate_artifacts
+
+        paths = generate_candidate_artifacts("stage1", "K4", "OBKR" * 10, SAMPLE_CANDIDATES, out_dir=str(tmp_path))
+        assert "json" in paths and "db_run_id" not in paths
+        data = json.loads((tmp_path / "k4_candidates.json").read_text(encoding="utf-8"))
+        assert data["candidate_count"] == 2
+
+    def test_persist_db_false_forces_skip(self, tmp_path, monkeypatch):
+        # Even if a (fake) URL is set, persist_db=False must not attempt a write
+        monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+        from kryptos.k4.reporting import generate_candidate_artifacts
+
+        paths = generate_candidate_artifacts(
+            "stage1", "K4", "OBKR" * 10, SAMPLE_CANDIDATES, out_dir=str(tmp_path), persist_db=False
+        )
+        assert "db_run_id" not in paths
+
+
+@pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="DATABASE_URL not set")
+class TestLivePersistence:
+    @pytest.fixture(autouse=True)
+    def _schema_and_cleanup(self):
+        from kryptos.db import get_conn
+        from kryptos.db_schema import init_schema
+
+        init_schema()
+        yield
+        # Remove rows created by this test (candidates cascade via run id)
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM candidates WHERE text LIKE %s", ("__pers_test__%",))
+                cur.execute("DELETE FROM campaign_runs WHERE label = %s", ("__pers_test__",))
+
+    def test_persist_and_read_back(self):
+        candidates = [
+            {
+                "score": -5.0,
+                "source": "q3",
+                "key": [[2, 3], [4, 5]],
+                "text": "__pers_test__TOP",
+                "metrics": {"ic": 0.07},
+            },
+            {"score": -9.0, "source": "q3", "key": None, "text": "__pers_test__SECOND", "metrics": {}},
+        ]
+        run_id = persist_campaign_candidates("__pers_test__", "__pers_test__", "OBKRUOX", candidates)
+        assert isinstance(run_id, int)
+
+        cands = fetch_run_candidates(run_id)
+        assert [c["rank"] for c in cands] == [1, 2]
+        assert cands[0]["text"] == "__pers_test__TOP"
+        assert cands[0]["key"] == [[2, 3], [4, 5]]  # jsonb round-trips to list
+        assert cands[0]["key_hash"] is not None
+        assert cands[1]["key"] is None
+
+        runs = fetch_recent_runs()
+        assert any(r["id"] == run_id for r in runs)
+
+    def test_persist_respects_limit(self):
+        many = [
+            {"score": -float(i), "source": "q3", "key": None, "text": f"__pers_test__{i}", "metrics": {}}
+            for i in range(10)
+        ]
+        run_id = persist_campaign_candidates("__pers_test__", "__pers_test__", "OBKR", many, limit=3)
+        assert len(fetch_run_candidates(run_id)) == 3


### PR DESCRIPTION
## Summary
The `campaign_runs`/`candidates` Neon tables were created in PR #93 but nothing populated them — candidate output lived only in `artifacts/*.json`. This wires the **write path** (option #2 from the post-checklist plan), giving the upcoming dashboard API real run history to serve and de-risking the schema against real round-trips.

- **`kryptos.persistence`**:
  - `persist_campaign_candidates()` creates one `campaign_runs` row and inserts ranked `candidates` rows when `DATABASE_URL` is set
  - `fetch_recent_runs()` / `fetch_run_candidates()` read them back (ready for the API layer)
  - **best-effort throughout**: missing `DATABASE_URL`, absent `psycopg2`, or any DB error is logged at WARNING and swallowed — persistence is never on the critical path of a cryptanalysis run
- **`k4.reporting.generate_candidate_artifacts`** now mirrors its JSON/CSV output to Neon when `DATABASE_URL` is configured (`persist_db=None` auto-detects; `True`/`False` force/skip), returning the new run id under the `'db_run_id'` key. File artifacts are always written regardless.

## Verified live against Neon
- candidate artifact generation persists a run + its candidates and reads them back; the `jsonb` key column round-trips `[[1,2],[3,4]]` to a Python list, rank ordering and `limit` are honored
- end-to-end: `generate_candidate_artifacts(...)` returned `db_run_id` and the row was queryable, then cleaned up

## Test plan
- [x] `tests/functional/test_persistence.py` (7 tests): DB-disabled no-ops, reporting integration (skip when disabled, `persist_db=False` forces skip), and live persist→read-back + limit — all pass against live Neon in Docker; live tests skip cleanly without `DATABASE_URL` (as in CI)
- [x] Full suite in Docker: 979 passed (same 6 known bind-mount/permission artifacts as main, pass in CI)

## Next
With write paths live, the follow-on is the FastAPI dashboard endpoints (`/api/runs`, `/api/candidates`, …) reading via `fetch_recent_runs`/`fetch_run_candidates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)