### PR TITLE
feat: K1-K3 animated decoder page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,8 +2,12 @@ import { useEffect, useState } from "react";
 import { api, StatusResponse } from "./api";
 import Topbar from "./components/Topbar";
 import OpsCenter from "./pages/OpsCenter";
+import Decode from "./pages/Decode";
+
+type Page = "ops" | "decode";
 
 export default function App() {
+  const [page, setPage] = useState<Page>("ops");
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -25,14 +29,22 @@ export default function App() {
   return (
     <div className="app">
       <Topbar status={status} />
+      <nav className="nav">
+        <button className={page === "ops" ? "active" : ""} onClick={() => setPage("ops")}>
+          Ops Center
+        </button>
+        <button className={page === "decode" ? "active" : ""} onClick={() => setPage("decode")}>
+          Decode
+        </button>
+      </nav>
       <main className="main">
         {error && <div className="banner">API unreachable: {error}</div>}
-        {status && !status.db_enabled && (
+        {page === "ops" && status && !status.db_enabled && (
           <div className="banner">
             DATABASE_URL not configured — run history is empty. Decrypt still works.
           </div>
         )}
-        <OpsCenter status={status} />
+        {page === "ops" ? <OpsCenter status={status} /> : <Decode />}
       </main>
     </div>
   );

--- a/frontend/src/cipher.ts
+++ b/frontend/src/cipher.ts
@@ -1,0 +1,144 @@
+// Client-side reimplementations of the solved-section ciphers, mirroring
+// kryptos.ciphers exactly, so the Decode page can animate each step without a
+// round-trip. Verified against the canonical K1/K2/K3 plaintexts.
+
+export const KEYED_ALPHABET = "KRYPTOSABCDEFGHIJLMNQUVWXZ";
+
+export interface SubStep {
+  cipher: string;
+  key: string;
+  plain: string;
+  cipherIdx: number;
+  keyIdx: number;
+  plainIdx: number;
+}
+
+/** Build a keyword-mixed alphabet (KRYPTOS -> KRYPTOSABCDEFGHIJLMNQUVWXZ). */
+export function keyedAlphabet(keyword: string): string {
+  const base = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const seen: string[] = [];
+  for (const ch of (keyword + base).toUpperCase()) {
+    if (base.includes(ch) && !seen.includes(ch)) seen.push(ch);
+  }
+  return seen.join("");
+}
+
+/**
+ * Keyed-alphabet Vigenère decryption (K1/K2 method): for each cipher letter,
+ * P = KEYED[(KEYED.index(C) - KEYED.index(K)) mod 26]. Returns per-letter steps.
+ */
+export function vigenereSteps(ciphertext: string, key: string): SubStep[] {
+  const cleanKey = key.toUpperCase().replace(/[^A-Z]/g, "");
+  const steps: SubStep[] = [];
+  let ki = 0;
+  for (const raw of ciphertext.toUpperCase()) {
+    if (raw < "A" || raw > "Z") continue;
+    const k = cleanKey[ki % cleanKey.length];
+    const cipherIdx = KEYED_ALPHABET.indexOf(raw);
+    const keyIdx = KEYED_ALPHABET.indexOf(k);
+    const plainIdx = (((cipherIdx - keyIdx) % 26) + 26) % 26;
+    steps.push({ cipher: raw, key: k, plain: KEYED_ALPHABET[plainIdx], cipherIdx, keyIdx, plainIdx });
+    ki += 1;
+  }
+  return steps;
+}
+
+export function decodeVigenere(ciphertext: string, key: string): string {
+  return vigenereSteps(ciphertext, key)
+    .map((s) => s.plain)
+    .join("");
+}
+
+export type Grid = string[][];
+
+/** Rows of `cols` chars (last row padded with spaces). */
+export function toGrid(text: string, cols: number): Grid {
+  const rows = Math.ceil(text.length / cols);
+  const g: Grid = [];
+  let idx = 0;
+  for (let r = 0; r < rows; r++) {
+    const row: string[] = [];
+    for (let c = 0; c < cols; c++) row.push(idx < text.length ? text[idx++] : " ");
+    g.push(row);
+  }
+  return g;
+}
+
+/** Rotate a grid 90° clockwise — mirrors kryptos.ciphers._rotate_right. */
+export function rotateRight(g: Grid): Grid {
+  const rows = g.length;
+  if (rows === 0) return [];
+  const cols = g[0].length;
+  const out: Grid = [];
+  for (let c = 0; c < cols; c++) {
+    const row: string[] = [];
+    for (let r = rows - 1; r >= 0; r--) row.push(g[r][c]);
+    out.push(row);
+  }
+  return out;
+}
+
+export function gridToText(g: Grid): string {
+  return g.map((row) => row.join("")).join("");
+}
+
+export interface K3Stage {
+  label: string;
+  grid: Grid;
+}
+
+/**
+ * K3 double rotational transposition stages (24×14 fill → 90cw → reshape to 8
+ * cols → 90cw), mirroring kryptos.ciphers.double_rotational_transposition.
+ */
+export function k3Stages(ciphertext: string): K3Stage[] {
+  const clean = ciphertext.replace(/\s/g, "").replace(/^\?/, "");
+  const m1 = toGrid(clean, 24);
+  const m2 = rotateRight(m1);
+  const t1 = gridToText(m2);
+  const m3 = toGrid(t1, 8);
+  const m4 = rotateRight(m3);
+  return [
+    { label: "1 · Fill 24-column grid (14 rows)", grid: m1 },
+    { label: "2 · Rotate 90° clockwise", grid: m2 },
+    { label: "3 · Reshape to 8 columns", grid: m3 },
+    { label: "4 · Rotate 90° clockwise → plaintext", grid: m4 },
+  ];
+}
+
+export function decodeK3(ciphertext: string): string {
+  const stages = k3Stages(ciphertext);
+  return gridToText(stages[stages.length - 1].grid).replace(/\s+$/, "");
+}
+
+// Canonical solved-section inputs (public Kryptos data, from config/config.json).
+// Spaces and `?` markers are stripped by the decode functions above.
+export const SECTION_DATA = {
+  K1: {
+    cipher: "EMUFPHZLRFAXYUSDJKZLDKRNSHGNFIVJYQTQUXQBQVYUVLLTREVJYQTMKYRDMFD",
+    key: "PALIMPSEST",
+    note: "Vigenère with the KRYPTOS-keyed alphabet. Watch for the deliberate misspelling IQLUSION.",
+  },
+  K2: {
+    cipher:
+      "VFPJUDEEHZWETZYVGWHKKQETGFQJNCE GGWHKK?DQMCPFQZDQMMIAGPFXHQRLG " +
+      "TIMVMZJANQLVKQEDAGDVFRPJUNGEUNA QZGZLECGYUXUEENJTBJLBQCRTBJDFHRR " +
+      "YIZETKZEMVDUFKSJHKFWHKUWQLSZFTI HHDDDUVH?DWKBFUFPWNTDFIYCUQZERE " +
+      "EVLDKFEZMOQQJLTTUGSYQPFEUNLAVIDX FLGGTEZ?FKZBSFDQVGOGIPUFXHHDRKF " +
+      "FHQNTGPUAECNUVPDJMQCLQUMUNEDFQ ELZZVRRGKFFVOEEXBDMVPNFQXEZLGRE " +
+      "DNQFMPNZGLFLPMRJQYALMGNUVPDXVKP DQUMEBEDMHDAFMJGZNUPLGESWJLLAETG",
+    key: "ABSCISSA",
+    note: "Same method as K1. The ? marks are structural nulls, not part of the message.",
+  },
+  K3: {
+    cipher:
+      "?ENDYAHROHNLSRHEOCPTEOIBIDYSHNAIACHTNREYULDSLLSLLNOHSNOSMRWXMNE" +
+      "TPRNGATIHNRARPESLNNELEBLPIIACAEWMTWNDITEENRAHCTENEUDRETNHAEOETFOL" +
+      "SEDTIWENHAEIOYTEYQHEENCTAYCREIFTBRSPAMHHEWENATAMATEGYEERLBTEEFOAS" +
+      "FIOTUETUAEOTOARMAEERTNRTIBSEDDNIAAHTTMSTEWPIEROAGRIEWFEBAECTDDHIL" +
+      "CEIHSITEGOEAOSDDRYDLORITRKLMLEHAGTDHARDPNEOHMGFMFEUHEECDMRIPFEIME" +
+      "HNLSSTTRTVDOHW",
+    key: null,
+    note: "Double rotational transposition — no substitution. Reveals DESPARATLY (sic).",
+  },
+} as const;

--- a/frontend/src/components/GridStages.tsx
+++ b/frontend/src/components/GridStages.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Grid, k3Stages } from "../cipher";
+
+function GridView({ grid }: { grid: Grid }) {
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "auto", borderCollapse: "collapse" }}>
+        <tbody>
+          {grid.map((row, r) => (
+            <tr key={r}>
+              {row.map((ch, c) => (
+                <td
+                  key={c}
+                  style={{
+                    border: "0.5px solid var(--border)",
+                    padding: "1px 4px",
+                    textAlign: "center",
+                    color: ch === " " ? "var(--border)" : "var(--text)",
+                  }}
+                >
+                  {ch === " " ? "·" : ch}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Stepped K3 double-rotational-transposition visualizer: fill 24-col grid,
+// rotate 90cw, reshape to 8 cols, rotate 90cw -> plaintext.
+export default function GridStages({ cipher }: { cipher: string }) {
+  const stages = k3Stages(cipher);
+  const [step, setStep] = useState(0);
+  const stage = stages[step];
+
+  return (
+    <div>
+      <div className="row" style={{ alignItems: "center", marginBottom: 12 }}>
+        <button onClick={() => setStep((s) => Math.max(0, s - 1))} disabled={step === 0}>
+          ◀ Prev
+        </button>
+        <button onClick={() => setStep((s) => Math.min(stages.length - 1, s + 1))} disabled={step === stages.length - 1}>
+          Next ▶
+        </button>
+        <span className="muted">
+          stage {step + 1}/{stages.length}
+        </span>
+      </div>
+      <div className="field">
+        <label>{stage.label}</label>
+        <div className="muted" style={{ fontSize: 11 }}>
+          {stage.grid.length} rows × {stage.grid[0]?.length ?? 0} cols
+        </div>
+      </div>
+      <GridView grid={stage.grid} />
+    </div>
+  );
+}

--- a/frontend/src/components/SubstitutionAnimator.tsx
+++ b/frontend/src/components/SubstitutionAnimator.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { KEYED_ALPHABET, vigenereSteps } from "../cipher";
+
+// Animated keyed-alphabet Vigenère decryption for K1/K2: steps through each
+// cipher letter, showing its position in the keyed tableau and the recovered
+// plaintext letter, with play/pause and a speed control.
+export default function SubstitutionAnimator({ cipher, keyword }: { cipher: string; keyword: string }) {
+  const steps = useMemo(() => vigenereSteps(cipher, keyword), [cipher, keyword]);
+  const [pos, setPos] = useState(0); // number of letters revealed
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState(200); // ms per letter
+  const timer = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!playing) return;
+    if (pos >= steps.length) {
+      setPlaying(false);
+      return;
+    }
+    timer.current = window.setTimeout(() => setPos((p) => Math.min(p + 1, steps.length)), speed);
+    return () => {
+      if (timer.current) window.clearTimeout(timer.current);
+    };
+  }, [playing, pos, speed, steps.length]);
+
+  const current = pos < steps.length ? steps[pos] : null;
+  const plain = steps
+    .slice(0, pos)
+    .map((s) => s.plain)
+    .join("");
+
+  return (
+    <div>
+      <div className="row" style={{ alignItems: "center", marginBottom: 12 }}>
+        <button onClick={() => setPlaying((p) => !p)} disabled={pos >= steps.length}>
+          {playing ? "Pause" : pos >= steps.length ? "Done" : "Play"}
+        </button>
+        <button onClick={() => { setPlaying(false); setPos(0); }}>Reset</button>
+        <button onClick={() => setPos(steps.length)}>Skip to end</button>
+        <div className="field" style={{ margin: 0 }}>
+          <label>Speed {speed}ms</label>
+          <input
+            type="range"
+            min={40}
+            max={500}
+            step={20}
+            value={speed}
+            onChange={(e) => setSpeed(Number(e.target.value))}
+          />
+        </div>
+        <span className="muted">
+          {pos}/{steps.length}
+        </span>
+      </div>
+
+      {/* Keyed alphabet tableau with the active cipher/key/plain cells lit */}
+      <div className="field">
+        <label>Keyed alphabet (KRYPTOS)</label>
+        <div style={{ letterSpacing: 3 }}>
+          {KEYED_ALPHABET.split("").map((ch, i) => {
+            let color: string | undefined;
+            if (current && i === current.cipherIdx) color = "var(--warning)";
+            else if (current && i === current.keyIdx) color = "var(--highlight)";
+            else if (current && i === current.plainIdx) color = "var(--accent)";
+            return (
+              <span key={i} style={{ color, fontWeight: color ? "bold" : "normal" }}>
+                {ch}
+              </span>
+            );
+          })}
+        </div>
+        <div className="muted" style={{ fontSize: 11 }}>
+          <span style={{ color: "var(--warning)" }}>■ cipher</span>{"  "}
+          <span style={{ color: "var(--highlight)" }}>■ key</span>{"  "}
+          <span style={{ color: "var(--accent)" }}>■ plain</span>
+        </div>
+      </div>
+
+      {current && (
+        <div className="result">
+          C={current.cipher} (pos {current.cipherIdx}) − K={current.key} (pos {current.keyIdx}) ={" "}
+          <span style={{ color: "var(--accent)" }}>
+            P={current.plain} (pos {current.plainIdx})
+          </span>
+        </div>
+      )}
+
+      <div className="field" style={{ marginTop: 12 }}>
+        <label>Plaintext</label>
+        <div className="result plaintext" style={{ minHeight: 40 }}>
+          {plain}
+          <span style={{ color: "var(--warning)" }}>{current ? current.cipher.toLowerCase() : ""}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Decode.tsx
+++ b/frontend/src/pages/Decode.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { SECTION_DATA, decodeK3, decodeVigenere } from "../cipher";
+import { ApiError, api } from "../api";
+import SubstitutionAnimator from "../components/SubstitutionAnimator";
+import GridStages from "../components/GridStages";
+
+type Section = "K1" | "K2" | "K3";
+const SECTIONS: Section[] = ["K1", "K2", "K3"];
+
+function localPlaintext(section: Section): string {
+  const data = SECTION_DATA[section];
+  return section === "K3" ? decodeK3(data.cipher) : decodeVigenere(data.cipher, data.key ?? "");
+}
+
+export default function Decode() {
+  const [section, setSection] = useState<Section>("K1");
+  const [check, setCheck] = useState<string | null>(null);
+  const data = SECTION_DATA[section];
+
+  // Cross-check the client-side animation against the backend pipeline.
+  async function verify() {
+    setCheck("checking…");
+    try {
+      const resp = await api.decrypt(section, data.cipher, data.key ?? undefined);
+      const local = localPlaintext(section);
+      const match = resp.plaintext.replace(/\s+$/, "") === local.replace(/\s+$/, "");
+      setCheck(match ? "✓ matches backend /api/decrypt" : "✗ differs from backend");
+    } catch (e) {
+      setCheck(e instanceof ApiError ? `backend error [${e.status}]` : String(e));
+    }
+  }
+
+  return (
+    <>
+      <div className="panel">
+        <h2>K1–K3 decoder</h2>
+        <div className="body">
+          <div className="row" style={{ marginBottom: 12 }}>
+            {SECTIONS.map((s) => (
+              <button
+                key={s}
+                onClick={() => {
+                  setSection(s);
+                  setCheck(null);
+                }}
+                style={{ borderColor: s === section ? "var(--accent)" : "var(--border)" }}
+              >
+                {s}
+              </button>
+            ))}
+            <button onClick={verify}>Verify vs backend</button>
+            {check && <span className="muted">{check}</span>}
+          </div>
+          <div className="muted" style={{ marginBottom: 12 }}>
+            {data.note}
+          </div>
+          {section === "K3" ? (
+            <GridStages cipher={data.cipher} />
+          ) : (
+            <SubstitutionAnimator cipher={data.cipher} keyword={data.key ?? ""} />
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -96,6 +96,23 @@ a {
   background: var(--border);
 }
 
+/* Nav */
+.nav {
+  display: flex;
+  gap: 8px;
+  padding: 8px 16px;
+  border-bottom: 0.5px solid var(--border);
+}
+
+.nav button {
+  background: transparent;
+}
+
+.nav button.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 /* Layout */
 .main {
   padding: 16px;


### PR DESCRIPTION
## Summary
Second frontend slice — the **K1–K3 animated decoder** (`docs/analysis/K4-FRONTEND.md` §2), with a lightweight `Ops Center | Decode` nav (state-based, no router dependency added).

- **`frontend/src/cipher.ts`** — client-side reimplementations of the solved-section ciphers, mirroring `kryptos.ciphers` exactly: keyed-alphabet Vigenère (`vigenereSteps`) and the K3 double-rotational-transposition stages (`toGrid`/`rotateRight`). Canonical ciphertexts pulled from `config/config.json`. **Verified** against the real plaintexts (K1 → `IQLUSION`, K2 → `ITWASTOTALLYINVISIBLE`, K3 → `SLOWLYDESPARATLY`, 336 chars).
- **`SubstitutionAnimator`** (K1/K2) — letter-by-letter walk through the keyed tableau, highlighting the cipher/key/plain cells, with play/pause, reset, skip-to-end, and a speed slider; plaintext is revealed progressively.
- **`GridStages`** (K3) — stepped visualizer of the four transposition stages (24-col fill → 90° cw → 8-col reshape → 90° cw → plaintext), rendered as monospace grids.
- **"Verify vs backend"** button cross-checks the client-side animation result against `POST /api/decrypt`.

## Test plan
- [x] Client-side decode verified to match the canonical plaintexts (ran the TS logic in Node against the `config/config.json` ciphertexts)
- [x] `npm run build` (tsc typecheck + vite build) passes in `node:22-alpine` — 42 modules, clean bundle
- [x] The `frontend` CI job will run the same build

## Deferred (next slices)
Vault page, Database admin page, SSE live-log tail (`/api/stream/logs` — needs the backend SSE endpoint first), and serving the built bundle from FastAPI via `StaticFiles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)