### PR TITLE
feat: Database admin page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,9 @@ import { api, StatusResponse } from "./api";
 import Topbar from "./components/Topbar";
 import OpsCenter from "./pages/OpsCenter";
 import Decode from "./pages/Decode";
+import Database from "./pages/Database";
 
-type Page = "ops" | "decode";
+type Page = "ops" | "decode" | "database";
 
 export default function App() {
   const [page, setPage] = useState<Page>("ops");
@@ -36,6 +37,9 @@ export default function App() {
         <button className={page === "decode" ? "active" : ""} onClick={() => setPage("decode")}>
           Decode
         </button>
+        <button className={page === "database" ? "active" : ""} onClick={() => setPage("database")}>
+          Database
+        </button>
       </nav>
       <main className="main">
         {error && <div className="banner">API unreachable: {error}</div>}
@@ -44,7 +48,9 @@ export default function App() {
             DATABASE_URL not configured — run history is empty. Decrypt still works.
           </div>
         )}
-        {page === "ops" ? <OpsCenter status={status} /> : <Decode />}
+        {page === "ops" && <OpsCenter status={status} />}
+        {page === "decode" && <Decode />}
+        {page === "database" && <Database status={status} />}
       </main>
     </div>
   );

--- a/frontend/src/pages/Database.tsx
+++ b/frontend/src/pages/Database.tsx
@@ -1,0 +1,83 @@
+import { StatusResponse } from "../api";
+
+// Internal admin view (docs/analysis/K4-FRONTEND.md section 4): connection
+// status and per-table row counts, read from /api/status. No user-facing data.
+
+const TABLES = [
+  { name: "campaign_runs", desc: "One row per candidate-generating run" },
+  { name: "candidates", desc: "Ranked candidate decryptions per run" },
+  { name: "discovered_cribs", desc: "Crib candidates with source provenance" },
+  { name: "ops_decisions", desc: "Strategy decision log" },
+  { name: "strategy_kb", desc: "Accumulated attack knowledge" },
+];
+
+export default function Database({ status }: { status: StatusResponse | null }) {
+  const enabled = status?.db_enabled ?? false;
+  const counts = status?.table_counts ?? {};
+
+  return (
+    <>
+      <div className="panel">
+        <h2>Connection</h2>
+        <div className="body">
+          <div className="row" style={{ alignItems: "center" }}>
+            <span className="pip">
+              <span className={`dot ${enabled ? "green" : "grey"}`} />
+              {enabled ? "Neon connected" : "No database"}
+            </span>
+          </div>
+          {!enabled && (
+            <div className="banner" style={{ marginTop: 10 }}>
+              DATABASE_URL is not configured. Set it (e.g. a Neon connection string) and run{" "}
+              <code>kryptos db-init</code> to create the tables.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="panel">
+        <h2>Tables</h2>
+        <div className="body">
+          <table>
+            <thead>
+              <tr>
+                <th>Table</th>
+                <th>Rows</th>
+                <th>Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              {TABLES.map((t) => (
+                <tr key={t.name}>
+                  <td>{t.name}</td>
+                  <td style={{ color: "var(--accent)" }}>{enabled ? (counts[t.name] ?? 0) : "—"}</td>
+                  <td className="muted">{t.desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="panel">
+        <h2>Environment</h2>
+        <div className="body">
+          <table>
+            <tbody>
+              <tr>
+                <td>DATABASE_URL</td>
+                <td className="muted">Neon/Postgres connection string (read by kryptos.db)</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>kryptos db-init</code>
+                </td>
+                <td className="muted">Creates the tables above idempotently (kryptos.db_schema)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Third frontend slice — the **Database** admin page (`docs/analysis/K4-FRONTEND.md` §4) and a third nav entry (`Ops Center | Decode | Database`). Frontend-only; reuses the existing `/api/status` response (no backend change).

- **Connection status** — Neon connected / no database, from `db_enabled`
- **Per-table row counts** — `campaign_runs`, `candidates`, `discovered_cribs`, `ops_decisions`, `strategy_kb` from `table_counts`, with purpose descriptions
- **Environment reference** — `DATABASE_URL`, `kryptos db-init`
- Graceful when DB is off (shows a setup banner, `—` counts)

## Test plan
- [x] `npm run build` (tsc + vite 8) passes in `node:22-alpine` — clean bundle
- [x] The `frontend` CI job runs the same build

## Remaining frontend slices
FastAPI static-serving + multistage Dockerfile, Vault (backend seal/unseal + `vault_payloads` table, then UI), and the SSE live-log tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)