### PR TITLE
feat: embed turbovec RAG behind a new FastAPI app (kryptos serve)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -62,6 +62,7 @@ Last Updated: 2026-06-12
 
 - [x] **Wired `LinguistAgent` into `PlaintextValidator`** — new `enable_linguist` constructor flag (default `False`). `_init_linguist()` gates on `torch`/`transformers` availability and `LinguistAgent` construction, degrading to `linguist_available=False` on any failure. When enabled, `stage3_linguistic_validation()` adds a `"linguist"` key (confidence/perplexity/coherence/grammar_score/model_used/passed) alongside the existing heuristic fields; `_linguist_score()` and the new `batch_validate_linguist()` re-ranking helper both catch and log scoring exceptions, returning `None` rather than raising. Existing default (`enable_linguist=False`) behavior and `"linguist"`-key absence are unchanged. See `tests/functional/test_validator_linguist.py`.
 
+
 ### RAG API (turbovec) — semantic search over `artifacts/`
 
 - [x] **`kryptos serve`** — minimal FastAPI app (`src/kryptos/api/`) with `/health`, `/api/rag/status`,

--- a/src/kryptos/cli/main.py
+++ b/src/kryptos/cli/main.py
@@ -316,6 +316,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sp_benchmark.set_defaults(func=cmd_benchmark)
 
+
     return parser
 
     p = argparse.ArgumentParser(prog="kryptos", description="Kryptos research CLI")
@@ -485,6 +486,7 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
     print(format_results_table(rows))
     print(f"\nResults written to {args.out_dir}/results.json and {args.out_dir}/results.csv")
     return 0
+
 
 
 def cmd_keyspace_stats(args: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary

Implements the "Now" item #1 from `agent-board/docs/AI_STACK_STRATEGY.md`: embed turbovec into a minimal FastAPI app to give cipher/hypothesis RAG search over `artifacts/` with zero architectural risk.

**What's new:**
- `kryptos serve` CLI subcommand — starts the FastAPI server via uvicorn (`--host`, `--port`, `--reload`)
- `GET /health` — liveness check
- `GET /api/rag/status` — index state (indexed/not, chunk_count, model, built_at)
- `POST /api/rag/reindex` — rebuild the turbovec index over `artifacts/` on demand
- `GET /api/rag/search?q=...&k=10` — semantic search; 409 if not yet indexed

**Implementation:**
- `src/kryptos/rag/` — chunking (`.json`/`.md` → 1000-char chunks, 256KB skip), sentence-transformers embeddings (all-MiniLM-L6-v2, lru_cache'd), turbovec `IdMapIndex` (4-bit quantized) with JSON sidecar for id→chunk lookup
- `src/kryptos/api/app.py` — FastAPI `create_app(index=...)` factory for testability; module-level `app` instance for uvicorn
- `src/kryptos/paths.py` — `get_data_root()` + `get_turbovec_index_dir()` helpers following existing pattern
- `data/turbovec/` added to `.gitignore` (generated index derived from gitignored `artifacts/`)
- `httpx` added to `config/requirements-dev.txt` (TestClient dependency)
- turbovec, fastapi, uvicorn[standard] added to `config/requirements.txt`

## Test plan

- [ ] `pytest -m "not slow" -q` — fast suite unaffected (RAG/API tests are `@pytest.mark.slow`)
- [ ] `pytest tests/functional/test_rag_index.py tests/functional/test_api.py -v` — 8 new slow tests covering build, search, load round-trip, empty artifacts, 409 before index, status+search with prebuilt index, reindex endpoint
- [ ] `kryptos serve --port 8000` then `curl localhost:8000/health` → `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)