### PR TITLE
Serve frontend SPA from FastAPI + multistage Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,5 @@ reports
 *.pyc
 *.pyo
 *.log
+frontend/node_modules
+frontend/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
 # Multi-stage Dockerfile for a Python application
 
 # ================================
+# Stage 0: Frontend build
+# Builds the React/Vite SPA so it can be served by the FastAPI app.
+# ================================
+FROM node:22-alpine AS frontend
+WORKDIR /frontend
+
+# Install deps from lockfile first for better layer caching
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+# Build the production bundle into /frontend/dist
+COPY frontend/ ./
+RUN npm run build
+
+# ================================
 # Stage 1: Dependencies
 # ================================
 FROM python:3.11-slim AS deps
@@ -42,6 +57,10 @@ COPY --from=deps /usr/local/bin /usr/local/bin
 
 # Copy application code
 COPY . .
+
+# Copy the built SPA from the frontend stage and point the app at it
+COPY --from=frontend /frontend/dist /app/frontend/dist
+ENV KRYPTOS_FRONTEND_DIST=/app/frontend/dist
 
 # Change ownership to non-root user
 RUN chown -R appuser:appuser /app

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -408,6 +408,18 @@ is unset (they return `db_enabled: false` with empty results rather than errorin
 
 > SSE log streaming (`GET /api/stream/logs`) is a planned follow-up — it needs a log-source design and is not yet implemented.
 
+### Frontend SPA (static serving)
+
+When a built frontend bundle is present, `create_app()` mounts it at `/` via
+`StaticFiles(directory=..., html=True)`, so the dashboard SPA and the API ship
+from one process. The mount is added **last**, so `/api/*` and `/health` always
+take precedence; `html=True` serves `index.html` for unknown paths (client-side
+routing). The dist directory is resolved in order: `KRYPTOS_FRONTEND_DIST`, then
+`<repo>/frontend/dist`, then `<cwd>/frontend/dist` (a candidate counts only if it
+contains `index.html`). If no build is found, the API is served alone. The root
+`Dockerfile` builds the SPA in a `node:22-alpine` stage and sets
+`KRYPTOS_FRONTEND_DIST=/app/frontend/dist`.
+
 ---
 
 ## Neon DB tables (runtime storage)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,10 +5,11 @@ Terminal-aesthetic React SPA over the kryptos FastAPI backend
 `docs/reference/API_REFERENCE.md` (`/api/status`, `/api/runs`,
 `/api/runs/{id}/candidates`, `/api/candidates`, `POST /api/decrypt`).
 
-This first slice ships the **Ops Center** page (status, metric cards, top
-candidates, campaign run history with drill-down, and an ad-hoc decrypt
-panel). The K1–K3 animated decoder, Vault, Database admin, and the SSE
-live-log tail from `docs/analysis/K4-FRONTEND.md` are planned follow-ups.
+Shipped pages: **Ops Center** (status, metric cards, top candidates,
+campaign run history with drill-down, ad-hoc decrypt panel), **Decode**
+(K1–K3 animated decoder), and **Database** (Neon connection + per-table
+row counts). The Vault and the SSE live-log tail from
+`docs/analysis/K4-FRONTEND.md` are planned follow-ups.
 
 ## Develop (Docker)
 
@@ -33,7 +34,13 @@ docker run --rm -v "$(pwd)/frontend:/app" -w /app node:22-alpine \
 ```
 
 The production bundle is emitted to `frontend/dist/` (gitignored). FastAPI
-can serve it as static files in a later integration step.
+serves it automatically: `create_app()` mounts `frontend/dist` at `/`
+(via `StaticFiles(..., html=True)`) when a build is present, so the API
+and SPA ship from a single container. The dist location is discovered from
+`KRYPTOS_FRONTEND_DIST`, then `<repo>/frontend/dist`, then
+`<cwd>/frontend/dist`. The root `Dockerfile` builds the SPA in a
+`node:22-alpine` stage and copies it into the runtime image with
+`KRYPTOS_FRONTEND_DIST=/app/frontend/dist` set.
 
 ## Stack
 

--- a/src/kryptos/api/app.py
+++ b/src/kryptos/api/app.py
@@ -1,13 +1,43 @@
-"""FastAPI app: health check + turbovec RAG search over `artifacts/`."""
+"""FastAPI app: health check + turbovec RAG search + dashboard SPA."""
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import asdict
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Query
+from fastapi.staticfiles import StaticFiles
 
 from kryptos.api.dashboard import create_dashboard_router
 from kryptos.rag.index import ArtifactIndex
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_frontend_dist() -> Path | None:
+    """Locate the built frontend bundle, or None if it isn't present.
+
+    Order: KRYPTOS_FRONTEND_DIST env override, then <repo_root>/frontend/dist,
+    then <cwd>/frontend/dist. A dist counts only if it contains index.html.
+    """
+    candidates: list[Path] = []
+    override = os.environ.get("KRYPTOS_FRONTEND_DIST")
+    if override:
+        candidates.append(Path(override))
+    try:
+        from kryptos.paths import get_repo_root
+
+        candidates.append(get_repo_root() / "frontend" / "dist")
+    except Exception:  # noqa: BLE001 - repo-root discovery is best-effort
+        pass
+    candidates.append(Path.cwd() / "frontend" / "dist")
+
+    for c in candidates:
+        if c.is_dir() and (c / "index.html").is_file():
+            return c
+    return None
 
 
 def create_app(index: ArtifactIndex | None = None) -> FastAPI:
@@ -38,6 +68,15 @@ def create_app(index: ArtifactIndex | None = None) -> FastAPI:
             )
         results = index.search(q, k=k)
         return {"query": q, "results": [asdict(r) for r in results]}
+
+    # Mount the built SPA LAST so API routes (/api/*, /health) always win.
+    # html=True serves index.html for unknown paths (client-side routing).
+    dist = _resolve_frontend_dist()
+    if dist is not None:
+        app.mount("/", StaticFiles(directory=str(dist), html=True), name="spa")
+        logger.info("Serving frontend SPA from %s", dist)
+    else:
+        logger.info("No frontend dist found; serving API only")
 
     return app
 

--- a/tests/functional/test_api_static.py
+++ b/tests/functional/test_api_static.py
@@ -1,0 +1,64 @@
+"""Tests for serving the built frontend SPA from the FastAPI app."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kryptos.api import app as app_module
+from kryptos.api.app import _resolve_frontend_dist, create_app
+from kryptos.rag.index import ArtifactIndex
+
+pytestmark = pytest.mark.slow
+
+
+def _make_dist(tmp_path):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<!doctype html><title>kryptos</title>", encoding="utf-8")
+    (dist / "assets").mkdir()
+    (dist / "assets" / "app.js").write_text("console.log('kryptos');", encoding="utf-8")
+    return dist
+
+
+def test_resolve_frontend_dist_env_override(tmp_path, monkeypatch):
+    dist = _make_dist(tmp_path)
+    monkeypatch.setenv("KRYPTOS_FRONTEND_DIST", str(dist))
+    assert _resolve_frontend_dist() == dist
+
+
+def test_resolve_frontend_dist_ignores_dir_without_index(tmp_path, monkeypatch):
+    empty = tmp_path / "dist"
+    empty.mkdir()
+    monkeypatch.setenv("KRYPTOS_FRONTEND_DIST", str(empty))
+    # A dir without index.html never counts; the override is skipped.
+    assert _resolve_frontend_dist() != empty
+
+
+def test_spa_served_when_dist_present(tmp_path, monkeypatch):
+    dist = _make_dist(tmp_path)
+    monkeypatch.setenv("KRYPTOS_FRONTEND_DIST", str(dist))
+
+    client = TestClient(create_app(index=ArtifactIndex(index_dir=tmp_path / "index")))
+
+    # SPA index is served at root and for unknown client-side routes.
+    root = client.get("/")
+    assert root.status_code == 200
+    assert "kryptos" in root.text
+
+    asset = client.get("/assets/app.js")
+    assert asset.status_code == 200
+    assert "console.log" in asset.text
+
+    # API + health routes still win over the catch-all SPA mount.
+    assert client.get("/health").json() == {"status": "ok"}
+    assert client.get("/api/status").status_code == 200
+
+
+def test_api_only_when_dist_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(app_module, "_resolve_frontend_dist", lambda: None)
+
+    client = TestClient(create_app(index=ArtifactIndex(index_dir=tmp_path / "index")))
+
+    assert client.get("/health").json() == {"status": "ok"}
+    assert client.get("/api/status").status_code == 200
+    # No SPA mounted -> unknown path is a normal 404, not an index fallback.
+    assert client.get("/definitely-not-a-route").status_code == 404


### PR DESCRIPTION
## What

Ship the dashboard SPA and the API from a single process/container.

- `create_app()` mounts `frontend/dist` at `/` via `StaticFiles(..., html=True)` **when a build is present**. Mounted **last** so `/api/*` and `/health` always take precedence; `html=True` serves `index.html` for client-side routes.
- Dist discovery order: `KRYPTOS_FRONTEND_DIST` → `<repo>/frontend/dist` → `<cwd>/frontend/dist` (must contain `index.html`). No build found → API served alone.
- Root `Dockerfile`: new `node:22-alpine` frontend stage (`npm ci` + `npm run build`); its `dist` is copied into the runtime image with `KRYPTOS_FRONTEND_DIST=/app/frontend/dist`.
- `.dockerignore` excludes `frontend/node_modules` and `frontend/dist`.

## Tests

`tests/functional/test_api_static.py`:
- resolver via env override; ignores a dir without `index.html`
- SPA served at `/` and `/assets/*`; `/health` + `/api/status` still win
- graceful API-only fallback (unknown path → 404, not index)

## Verification (Docker)

- `docker build` succeeds — frontend stage builds, dist copied into runtime image.
- In the built image: `_resolve_frontend_dist()` → `/app/frontend/dist`; `/` returns the SPA index (200), `/health` 200, `/api/status` 200.

Docs: updated `docs/reference/API_REFERENCE.md` and `frontend/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)