### PR TITLE
Kryptos Vault backend: seal/unseal/peek API + vault_payloads table

### DIFF
--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -408,6 +408,23 @@ is unset (they return `db_enabled: false` with empty results rather than errorin
 
 > SSE log streaming (`GET /api/stream/logs`) is a planned follow-up — it needs a log-source design and is not yet implemented.
 
+### Vault (`kryptos.api.vault_routes` / `kryptos.vault`)
+
+Seal a secret under a keyed-alphabet Vigenère cipher, store it in Neon with a TTL
+and a server-enforced read limit, and get back an opaque UUID token. The **key is
+never stored** (only the ciphertext), so the database alone cannot reveal the
+plaintext. A short verifier hash lets a wrong key be rejected **without consuming
+a read**. The vault requires `DATABASE_URL`; without it every endpoint returns 503.
+
+| Method & path | Purpose |
+|---------------|---------|
+| `POST /api/vault/seal` | Body `{plaintext, key, ttl_seconds?=86400, max_reads?=1}` → `{token, cipher, max_reads, expires_at}` |
+| `POST /api/vault/unseal` | Body `{token, key}` → `{token, plaintext, reads_remaining, expires_at}`. Consumes one read |
+| `GET /api/vault/{token}` | Metadata only (no decrypt, no read consumed): `{status, max_reads, reads_used, reads_remaining, sealed_at, expires_at}` |
+
+Error mapping: unknown token → 404; expired/exhausted → 410; wrong key → 403;
+invalid arguments → 422; no database → 503. `ttl_seconds: 0` means no expiry.
+
 ### Frontend SPA (static serving)
 
 When a built frontend bundle is present, `create_app()` mounts it at `/` via
@@ -430,6 +447,7 @@ Schema defined in `kryptos.db_schema`; create with `kryptos db-init`.
 |-------|-----------|---------|
 | `campaign_runs` | `kryptos.persistence` (via `k4.reporting`) | One row per candidate-generating run |
 | `candidates` | `kryptos.persistence` (via `k4.reporting`) | Ranked candidate decryptions per run |
+| `vault_payloads` | `kryptos.vault` (via `POST /api/vault/seal`) | Sealed secrets: ciphertext, verifier, TTL, read limit |
 | `ops_decisions` | `OpsStrategicDirector` | Strategy decision log |
 | `strategy_kb` | Manual / future agents | Accumulated attack knowledge |
 | `discovered_cribs` | `SpyWebIntel` | Crib candidates with source provenance |

--- a/src/kryptos/api/app.py
+++ b/src/kryptos/api/app.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.staticfiles import StaticFiles
 
 from kryptos.api.dashboard import create_dashboard_router
+from kryptos.api.vault_routes import create_vault_router
 from kryptos.rag.index import ArtifactIndex
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,7 @@ def create_app(index: ArtifactIndex | None = None) -> FastAPI:
 
     app = FastAPI(title="Kryptos API", version="0.1.0")
     app.include_router(create_dashboard_router())
+    app.include_router(create_vault_router())
 
     @app.get("/health")
     def health() -> dict:

--- a/src/kryptos/api/vault_routes.py
+++ b/src/kryptos/api/vault_routes.py
@@ -1,0 +1,95 @@
+"""Vault API router: seal a secret, unseal it with a key, peek at its status.
+
+Backed by :mod:`kryptos.vault` and the ``vault_payloads`` Neon table. The vault
+requires ``DATABASE_URL``; without it these endpoints return 503. Vault errors
+map to HTTP status: not found -> 404, expired/exhausted -> 410, wrong key -> 403.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Path
+from pydantic import BaseModel, Field
+
+from kryptos import vault
+
+
+class SealRequest(BaseModel):
+    plaintext: str = Field(..., min_length=1, description="Secret to seal")
+    key: str = Field(..., min_length=1, description="Keyed-alphabet Vigenère key")
+    ttl_seconds: int = Field(86400, ge=0, le=vault.MAX_TTL_SECONDS, description="Lifetime in seconds; 0 = no expiry")
+    max_reads: int = Field(1, ge=1, le=vault.MAX_READS_CAP, description="Server-enforced read limit")
+
+
+class SealResponse(BaseModel):
+    token: str
+    cipher: str
+    max_reads: int
+    expires_at: str | None = None
+
+
+class UnsealRequest(BaseModel):
+    token: str = Field(..., min_length=1)
+    key: str = Field(..., min_length=1)
+
+
+class UnsealResponse(BaseModel):
+    token: str
+    plaintext: str
+    reads_remaining: int
+    expires_at: str | None = None
+
+
+class PeekResponse(BaseModel):
+    token: str
+    cipher: str
+    status: str
+    max_reads: int
+    reads_used: int
+    reads_remaining: int
+    sealed_at: str | None = None
+    expires_at: str | None = None
+
+
+def create_vault_router() -> APIRouter:
+    router = APIRouter(prefix="/api/vault", tags=["vault"])
+
+    @router.post("/seal", response_model=SealResponse)
+    def seal(req: SealRequest) -> SealResponse:
+        try:
+            result = vault.seal(req.plaintext, req.key, ttl_seconds=req.ttl_seconds, max_reads=req.max_reads)
+        except vault.VaultUnavailable as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return SealResponse(**result)
+
+    @router.post("/unseal", response_model=UnsealResponse)
+    def unseal(req: UnsealRequest) -> UnsealResponse:
+        try:
+            result = vault.unseal(req.token, req.key)
+        except vault.VaultUnavailable as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        except vault.VaultNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except vault.VaultGone as exc:
+            raise HTTPException(status_code=410, detail=str(exc)) from exc
+        except vault.VaultWrongKey as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return UnsealResponse(**result)
+
+    @router.get("/{token}", response_model=PeekResponse)
+    def peek(token: str = Path(..., min_length=1)) -> PeekResponse:
+        try:
+            result = vault.peek(token)
+        except vault.VaultUnavailable as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        except vault.VaultNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return PeekResponse(**result)
+
+    return router
+
+
+__all__ = ["create_vault_router"]

--- a/src/kryptos/ciphers.py
+++ b/src/kryptos/ciphers.py
@@ -15,7 +15,7 @@ KEYED_ALPHABET = "KRYPTOSABCDEFGHIJLMNQUVWXZ"
 
 
 def vigenere_decrypt(ciphertext: str, key: str, preserve_non_alpha: bool = False) -> str:
-    key = ''.join(c for c in key.upper() if c.isalpha())
+    key = "".join(c for c in key.upper() if c.isalpha())
     if not key:
         raise ValueError("Key must contain at least one alphabetic character")
     out: list[str] = []
@@ -46,12 +46,39 @@ def vigenere_decrypt(ciphertext: str, key: str, preserve_non_alpha: bool = False
             ki += 1
         elif preserve_non_alpha:
             out.append(ch)
-    return ''.join(out)
+    return "".join(out)
+
+
+def vigenere_encrypt(plaintext: str, key: str, preserve_non_alpha: bool = False) -> str:
+    """Inverse of :func:`vigenere_decrypt` over the KRYPTOS keyed alphabet.
+
+    Letters are encrypted ``(P + K) mod 26`` against ``KEYED_ALPHABET``;
+    non-alphabetic characters are dropped unless ``preserve_non_alpha`` is set.
+    Plaintext is upper-cased so it maps into the keyed alphabet.
+    """
+    key = "".join(c for c in key.upper() if c.isalpha())
+    if not key:
+        raise ValueError("Key must contain at least one alphabetic character")
+    out: list[str] = []
+    klen = len(KEYED_ALPHABET)
+    ki = 0
+    for ch in plaintext.upper():
+        if ch.isalpha():
+            try:
+                p_index = KEYED_ALPHABET.index(ch)
+                k_index = KEYED_ALPHABET.index(key[ki % len(key)])
+            except ValueError as e:
+                raise ValueError(f"Character '{ch}' or key char not in keyed alphabet") from e
+            out.append(KEYED_ALPHABET[(p_index + k_index) % klen])
+            ki += 1
+        elif preserve_non_alpha:
+            out.append(ch)
+    return "".join(out)
 
 
 def k3_decrypt(ciphertext: str) -> str:
-    clean = ''.join(ciphertext.split())
-    if clean.startswith('?'):
+    clean = "".join(ciphertext.split())
+    if clean.startswith("?"):
         clean = clean[1:]
     return double_rotational_transposition(clean)
 
@@ -63,12 +90,12 @@ def double_rotational_transposition(text: str) -> str:
         raise ValueError(f"K3 ciphertext must be {expected_len} chars (got {len(text)})")
     m1 = [list(text[i * cols1 : (i + 1) * cols1]) for i in range(rows1)]
     m2 = _rotate_right(m1)
-    t1 = ''.join(''.join(r) for r in m2)
+    t1 = "".join("".join(r) for r in m2)
     cols2 = 8
     rows2 = len(t1) // cols2
     m3 = [list(t1[i * cols2 : (i + 1) * cols2]) for i in range(rows2)]
     m4 = _rotate_right(m3)
-    return ''.join(''.join(r) for r in m4)
+    return "".join("".join(r) for r in m4)
 
 
 def _rotate_right(matrix: list[list[str]]) -> list[list[str]]:
@@ -92,8 +119,8 @@ def rotate_matrix_right_90(matrix: Sequence[Sequence[str]]) -> list[list[str]]:
 
 
 def transposition_decrypt(ciphertext: str, key: str | None = None) -> str:
-    clean = ''.join(ciphertext.split())
-    if clean.startswith('?'):
+    clean = "".join(ciphertext.split())
+    if clean.startswith("?"):
         clean = clean[1:]
     if key is None:
         return k3_decrypt(clean)
@@ -101,10 +128,10 @@ def transposition_decrypt(ciphertext: str, key: str | None = None) -> str:
     height = 4
     needed = width * height
     if len(clean) < needed:
-        clean = clean.ljust(needed, 'X')
+        clean = clean.ljust(needed, "X")
     if len(clean) != needed:
         raise ValueError(f"Expected ciphertext length {needed}, got {len(clean)}")
-    key_up = ''.join(c for c in key.upper() if c.isalpha())
+    key_up = "".join(c for c in key.upper() if c.isalpha())
     repeated_key = (key_up * ((width // len(key_up)) + 1))[:width]
     key_tuples = sorted((ch, idx) for idx, ch in enumerate(repeated_key))
     col_order = [idx for _ch, idx in key_tuples]
@@ -118,7 +145,7 @@ def transposition_decrypt(ciphertext: str, key: str | None = None) -> str:
         col_text = cols[order]
         for r in range(height):
             grid[r][orig_col] = col_text[r]
-    return ''.join(''.join(row) for row in grid)
+    return "".join("".join(row) for row in grid)
 
 
 def polybius_decrypt(ciphertext: str, key_square: Sequence[Sequence[str]]) -> str:
@@ -135,7 +162,7 @@ def polybius_decrypt(ciphertext: str, key_square: Sequence[Sequence[str]]) -> st
             out.append(key_square[r][c])
         except (ValueError, IndexError) as exc:
             raise ValueError(f"Invalid pair in ciphertext: {pair}") from exc
-    return ''.join(out)
+    return "".join(out)
 
 
 def beaufort_decrypt(ciphertext: str, key: str, preserve_non_alpha: bool = False) -> str:
@@ -152,6 +179,7 @@ def beaufort_encrypt(plaintext: str, key: str, preserve_non_alpha: bool = False)
 
 __all__ = [
     "vigenere_decrypt",
+    "vigenere_encrypt",
     "k3_decrypt",
     "double_rotational_transposition",
     "rotate_matrix_right_90",

--- a/src/kryptos/db_schema.py
+++ b/src/kryptos/db_schema.py
@@ -85,6 +85,19 @@ SCHEMA_STATEMENTS: dict[str, str] = {
         CREATE INDEX IF NOT EXISTS idx_candidates_score ON candidates (score DESC);
         CREATE INDEX IF NOT EXISTS idx_candidates_run ON candidates (campaign_run_id);
     """,
+    "vault_payloads": """
+        CREATE TABLE IF NOT EXISTS vault_payloads (
+            token       UUID PRIMARY KEY,
+            cipher      TEXT NOT NULL DEFAULT 'vigenere-keyed',
+            ciphertext  TEXT NOT NULL,
+            verifier    TEXT,
+            max_reads   INTEGER NOT NULL DEFAULT 1 CHECK (max_reads >= 1),
+            reads_used  INTEGER NOT NULL DEFAULT 0,
+            sealed_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+            expires_at  TIMESTAMPTZ
+        );
+        CREATE INDEX IF NOT EXISTS idx_vault_expires ON vault_payloads (expires_at);
+    """,
 }
 
 

--- a/src/kryptos/vault.py
+++ b/src/kryptos/vault.py
@@ -1,0 +1,222 @@
+"""Kryptos Vault — seal a secret with a keyed-alphabet cipher, store it in Neon
+with a TTL and a server-enforced read limit, and hand back an opaque token.
+
+Unlike :mod:`kryptos.persistence` (best-effort, never on the critical path), the
+vault *requires* a database: without ``DATABASE_URL`` the operations raise
+:class:`VaultUnavailable` so callers can surface a clear error.
+
+Security model (thematic, not a hardened secrets manager):
+
+- The payload is encrypted with the KRYPTOS keyed-alphabet Vigenère
+  (:func:`kryptos.ciphers.vigenere_encrypt`). The **key is never stored** — only
+  the ciphertext, so DB access alone does not reveal the plaintext.
+- A short ``verifier`` (sha256 prefix of the plaintext) is stored so a wrong key
+  can be rejected *without* consuming a read. This is a deliberate trade-off: it
+  enables offline guessing by anyone with DB access, acceptable for this feature.
+- The opaque ``token`` (UUIDv4) is the capability. A row self-destructs once
+  ``reads_used`` reaches ``max_reads`` or ``expires_at`` passes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from kryptos.ciphers import vigenere_decrypt, vigenere_encrypt
+
+logger = logging.getLogger(__name__)
+
+CIPHER_LABEL = "vigenere-keyed"
+MAX_TTL_SECONDS = 30 * 24 * 3600  # 30 days
+MAX_READS_CAP = 1000
+
+
+class VaultError(Exception):
+    """Base class for vault failures."""
+
+
+class VaultUnavailable(VaultError):
+    """Raised when no database is configured."""
+
+
+class VaultNotFound(VaultError):
+    """Raised when a token does not exist."""
+
+
+class VaultGone(VaultError):
+    """Raised when a payload is expired or its reads are exhausted."""
+
+
+class VaultWrongKey(VaultError):
+    """Raised when the supplied key does not decrypt the payload."""
+
+
+def vault_enabled() -> bool:
+    """True when a DATABASE_URL is configured (the vault needs storage)."""
+    from kryptos import persistence
+
+    return persistence.db_enabled()
+
+
+def _verifier(plaintext: str) -> str:
+    return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()[:16]
+
+
+def _require_db():
+    if not vault_enabled():
+        raise VaultUnavailable("DATABASE_URL is not configured; the vault is unavailable")
+    from kryptos.db import get_conn
+
+    return get_conn
+
+
+def seal(
+    plaintext: str,
+    key: str,
+    ttl_seconds: int = 86400,
+    max_reads: int = 1,
+) -> dict[str, Any]:
+    """Encrypt ``plaintext`` under ``key`` and store it; return the access token.
+
+    Returns ``{token, expires_at, max_reads, cipher}``. ``expires_at`` is None
+    when ``ttl_seconds`` is 0 (no expiry). Raises :class:`VaultUnavailable` if no
+    database is configured, or ``ValueError`` for invalid arguments.
+    """
+    if not plaintext:
+        raise ValueError("plaintext must not be empty")
+    if max_reads < 1:
+        raise ValueError("max_reads must be >= 1")
+    max_reads = min(max_reads, MAX_READS_CAP)
+    if ttl_seconds < 0:
+        raise ValueError("ttl_seconds must be >= 0")
+    ttl_seconds = min(ttl_seconds, MAX_TTL_SECONDS)
+
+    get_conn = _require_db()
+    # vigenere_encrypt validates the key has usable alphabetic characters.
+    ciphertext = vigenere_encrypt(plaintext, key, preserve_non_alpha=True)
+    token = str(uuid.uuid4())
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds) if ttl_seconds > 0 else None
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO vault_payloads"
+                " (token, cipher, ciphertext, verifier, max_reads, reads_used, expires_at)"
+                " VALUES (%s, %s, %s, %s, %s, 0, %s)",
+                (token, CIPHER_LABEL, ciphertext, _verifier(plaintext), max_reads, expires_at),
+            )
+    logger.info("Sealed vault payload %s (max_reads=%s, ttl=%ss)", token, max_reads, ttl_seconds)
+    return {
+        "token": token,
+        "cipher": CIPHER_LABEL,
+        "max_reads": max_reads,
+        "expires_at": expires_at.isoformat() if expires_at else None,
+    }
+
+
+def peek(token: str) -> dict[str, Any]:
+    """Return metadata for a token without decrypting or consuming a read.
+
+    Raises :class:`VaultNotFound` if the token is unknown. An expired/exhausted
+    payload is still reported (``status`` reflects it) so the UI can explain why.
+    """
+    get_conn = _require_db()
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT cipher, max_reads, reads_used, sealed_at, expires_at" " FROM vault_payloads WHERE token = %s",
+                (token,),
+            )
+            row = cur.fetchone()
+    if row is None:
+        raise VaultNotFound(f"No vault payload for token {token}")
+    cipher, max_reads, reads_used, sealed_at, expires_at = row
+    return {
+        "token": token,
+        "cipher": cipher,
+        "status": _status(reads_used, max_reads, expires_at),
+        "max_reads": max_reads,
+        "reads_used": reads_used,
+        "reads_remaining": max(0, max_reads - reads_used),
+        "sealed_at": sealed_at.isoformat() if sealed_at else None,
+        "expires_at": expires_at.isoformat() if expires_at else None,
+    }
+
+
+def unseal(token: str, key: str) -> dict[str, Any]:
+    """Decrypt a payload with ``key`` and consume one read.
+
+    A wrong key raises :class:`VaultWrongKey` *without* burning a read. Expired or
+    exhausted payloads raise :class:`VaultGone`; unknown tokens raise
+    :class:`VaultNotFound`. Returns ``{plaintext, reads_remaining, expires_at}``.
+    """
+    get_conn = _require_db()
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT ciphertext, verifier, max_reads, reads_used, expires_at"
+                " FROM vault_payloads WHERE token = %s",
+                (token,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise VaultNotFound(f"No vault payload for token {token}")
+            ciphertext, verifier, max_reads, reads_used, expires_at = row
+
+            if _is_expired(expires_at):
+                raise VaultGone("Vault payload has expired")
+            if reads_used >= max_reads:
+                raise VaultGone("Vault payload has no reads remaining")
+
+            plaintext = vigenere_decrypt(ciphertext, key, preserve_non_alpha=True)
+            if verifier is not None and _verifier(plaintext) != verifier:
+                raise VaultWrongKey("Key did not decrypt the payload")
+
+            # Atomically claim a read; if another caller raced us to the last
+            # read, RETURNING yields nothing and we report the payload as gone.
+            cur.execute(
+                "UPDATE vault_payloads SET reads_used = reads_used + 1"
+                " WHERE token = %s AND reads_used < max_reads RETURNING reads_used",
+                (token,),
+            )
+            updated = cur.fetchone()
+            if updated is None:
+                raise VaultGone("Vault payload has no reads remaining")
+            new_reads_used = updated[0]
+
+    logger.info("Unsealed vault payload %s (read %s/%s)", token, new_reads_used, max_reads)
+    return {
+        "token": token,
+        "plaintext": plaintext,
+        "reads_remaining": max(0, max_reads - new_reads_used),
+        "expires_at": expires_at.isoformat() if expires_at else None,
+    }
+
+
+def _is_expired(expires_at: datetime | None) -> bool:
+    return expires_at is not None and expires_at <= datetime.now(timezone.utc)
+
+
+def _status(reads_used: int, max_reads: int, expires_at: datetime | None) -> str:
+    if _is_expired(expires_at):
+        return "expired"
+    if reads_used >= max_reads:
+        return "exhausted"
+    return "sealed"
+
+
+__all__ = [
+    "seal",
+    "unseal",
+    "peek",
+    "vault_enabled",
+    "VaultError",
+    "VaultUnavailable",
+    "VaultNotFound",
+    "VaultGone",
+    "VaultWrongKey",
+    "CIPHER_LABEL",
+]

--- a/tests/functional/test_db_schema.py
+++ b/tests/functional/test_db_schema.py
@@ -10,7 +10,14 @@ import pytest
 
 from kryptos.db_schema import SCHEMA_STATEMENTS, init_schema
 
-EXPECTED_TABLES = {"strategy_kb", "ops_decisions", "discovered_cribs", "campaign_runs", "candidates"}
+EXPECTED_TABLES = {
+    "strategy_kb",
+    "ops_decisions",
+    "discovered_cribs",
+    "campaign_runs",
+    "candidates",
+    "vault_payloads",
+}
 
 # Marker so live tests never collide with (or delete) real rows
 _TEST_TAG = "__kryptos_test__"

--- a/tests/functional/test_vault.py
+++ b/tests/functional/test_vault.py
@@ -1,0 +1,217 @@
+"""Vault tests: cipher round-trip, seal/unseal/peek flow, and HTTP error mapping.
+
+A small in-memory fake stands in for the Neon ``vault_payloads`` table so the
+real seal -> unseal -> peek logic (including expiry, exhaustion, wrong-key, and
+the atomic read-decrement) is exercised without Postgres.
+"""
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kryptos import vault
+from kryptos.api.app import create_app
+from kryptos.ciphers import vigenere_decrypt, vigenere_encrypt
+from kryptos.rag.index import ArtifactIndex
+
+pytestmark = pytest.mark.slow
+
+
+# --- Cipher round-trip --------------------------------------------------------
+
+
+def test_vigenere_encrypt_decrypt_roundtrip():
+    plain = "MEET AT THE BERLIN CLOCK"
+    ct = vigenere_encrypt(plain, "PALIMPSEST", preserve_non_alpha=True)
+    assert ct != plain
+    assert vigenere_decrypt(ct, "PALIMPSEST", preserve_non_alpha=True) == plain
+
+
+# --- Fake DB ------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, store):
+        self._store = store
+        self._result = None
+
+    def execute(self, sql, params=()):
+        s = " ".join(sql.split())
+        if s.startswith("INSERT INTO vault_payloads"):
+            token, cipher, ciphertext, verifier, max_reads, expires_at = params
+            self._store[token] = {
+                "cipher": cipher,
+                "ciphertext": ciphertext,
+                "verifier": verifier,
+                "max_reads": max_reads,
+                "reads_used": 0,
+                "sealed_at": datetime.now(timezone.utc),
+                "expires_at": expires_at,
+            }
+            self._result = None
+        elif s.startswith("SELECT cipher, max_reads, reads_used"):  # peek
+            row = self._store.get(params[0])
+            self._result = (
+                (row["cipher"], row["max_reads"], row["reads_used"], row["sealed_at"], row["expires_at"])
+                if row
+                else None
+            )
+        elif s.startswith("SELECT ciphertext, verifier"):  # unseal load
+            row = self._store.get(params[0])
+            self._result = (
+                (row["ciphertext"], row["verifier"], row["max_reads"], row["reads_used"], row["expires_at"])
+                if row
+                else None
+            )
+        elif s.startswith("UPDATE vault_payloads SET reads_used"):
+            row = self._store.get(params[0])
+            if row and row["reads_used"] < row["max_reads"]:
+                row["reads_used"] += 1
+                self._result = (row["reads_used"],)
+            else:
+                self._result = None
+        else:  # pragma: no cover - unexpected SQL
+            raise AssertionError(f"Unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, store):
+        self._store = store
+
+    def cursor(self):
+        return _FakeCursor(self._store)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def fake_vault(monkeypatch):
+    store: dict = {}
+
+    @contextmanager
+    def _get_conn():
+        yield _FakeConn(store)
+
+    monkeypatch.setattr(vault, "_require_db", lambda: _get_conn)
+    return store
+
+
+# --- Module-level flow --------------------------------------------------------
+
+
+def test_seal_then_unseal_roundtrip(fake_vault):
+    sealed = vault.seal("ATTACK AT DAWN", "KRYPTOS", ttl_seconds=3600, max_reads=2)
+    token = sealed["token"]
+    assert sealed["cipher"] == vault.CIPHER_LABEL
+    assert sealed["max_reads"] == 2
+
+    opened = vault.unseal(token, "KRYPTOS")
+    assert opened["plaintext"] == "ATTACK AT DAWN"
+    assert opened["reads_remaining"] == 1
+
+
+def test_wrong_key_does_not_consume_read(fake_vault):
+    token = vault.seal("SECRET", "RIGHTKEY", max_reads=1)["token"]
+    with pytest.raises(vault.VaultWrongKey):
+        vault.unseal(token, "WRONGKEY")
+    # Read was not burned: the correct key still works.
+    assert vault.unseal(token, "RIGHTKEY")["plaintext"] == "SECRET"
+
+
+def test_exhausted_after_max_reads(fake_vault):
+    token = vault.seal("ONESHOT", "KEY", max_reads=1)["token"]
+    assert vault.unseal(token, "KEY")["reads_remaining"] == 0
+    with pytest.raises(vault.VaultGone):
+        vault.unseal(token, "KEY")
+
+
+def test_expired_payload_is_gone(fake_vault):
+    token = vault.seal("OLD", "KEY", ttl_seconds=3600)["token"]
+    fake_vault[token]["expires_at"] = datetime.now(timezone.utc) - timedelta(seconds=1)
+    with pytest.raises(vault.VaultGone):
+        vault.unseal(token, "KEY")
+
+
+def test_peek_reports_status(fake_vault):
+    token = vault.seal("HELLO", "KEY", max_reads=1)["token"]
+    meta = vault.peek(token)
+    assert meta["status"] == "sealed"
+    assert meta["reads_remaining"] == 1
+    vault.unseal(token, "KEY")
+    assert vault.peek(token)["status"] == "exhausted"
+
+
+def test_unknown_token_not_found(fake_vault):
+    with pytest.raises(vault.VaultNotFound):
+        vault.peek("00000000-0000-0000-0000-000000000000")
+
+
+def test_seal_requires_database(monkeypatch):
+    monkeypatch.setattr(vault, "vault_enabled", lambda: False)
+    with pytest.raises(vault.VaultUnavailable):
+        vault.seal("X", "KEY")
+
+
+# --- HTTP layer ---------------------------------------------------------------
+
+
+def _client(tmp_path):
+    return TestClient(create_app(index=ArtifactIndex(index_dir=tmp_path / "index")))
+
+
+def test_http_seal_unseal_peek(fake_vault, tmp_path):
+    client = _client(tmp_path)
+
+    resp = client.post(
+        "/api/vault/seal",
+        json={"plaintext": "BERLIN CLOCK", "key": "ABSCISSA", "ttl_seconds": 600, "max_reads": 1},
+    )
+    assert resp.status_code == 200
+    token = resp.json()["token"]
+
+    meta = client.get(f"/api/vault/{token}")
+    assert meta.status_code == 200
+    assert meta.json()["status"] == "sealed"
+
+    opened = client.post("/api/vault/unseal", json={"token": token, "key": "ABSCISSA"})
+    assert opened.status_code == 200
+    assert opened.json()["plaintext"] == "BERLIN CLOCK"
+
+    # Second unseal -> 410 Gone (max_reads exhausted).
+    again = client.post("/api/vault/unseal", json={"token": token, "key": "ABSCISSA"})
+    assert again.status_code == 410
+
+
+def test_http_wrong_key_403(fake_vault, tmp_path):
+    client = _client(tmp_path)
+    token = client.post("/api/vault/seal", json={"plaintext": "X", "key": "RIGHT"}).json()["token"]
+    resp = client.post("/api/vault/unseal", json={"token": token, "key": "WRONG"})
+    assert resp.status_code == 403
+
+
+def test_http_unknown_token_404(fake_vault, tmp_path):
+    client = _client(tmp_path)
+    resp = client.get("/api/vault/11111111-1111-1111-1111-111111111111")
+    assert resp.status_code == 404
+
+
+def test_http_unavailable_503(monkeypatch, tmp_path):
+    monkeypatch.setattr(vault, "vault_enabled", lambda: False)
+    client = _client(tmp_path)
+    resp = client.post("/api/vault/seal", json={"plaintext": "X", "key": "K"})
+    assert resp.status_code == 503


### PR DESCRIPTION
## What

A **Vault**: seal a secret under the KRYPTOS keyed-alphabet Vigenère, store it in Neon with a TTL and a server-enforced read limit, and get back an opaque UUID token.

- The **key is never stored** (only the ciphertext) — DB access alone cannot reveal the plaintext.
- A short `verifier` (sha256 prefix of the plaintext) lets a **wrong key be rejected without consuming a read**. Documented trade-off: enables offline guessing by anyone with DB access — acceptable for this thematic feature, not a hardened secrets manager.
- A row is "gone" once `reads_used == max_reads` or `expires_at` passes. The read-decrement is an atomic conditional `UPDATE ... RETURNING`.

## Endpoints (`kryptos.api.vault_routes`)

| Method & path | Purpose |
|---------------|---------|
| `POST /api/vault/seal` | `{plaintext, key, ttl_seconds?=86400, max_reads?=1}` → `{token, cipher, max_reads, expires_at}` |
| `POST /api/vault/unseal` | `{token, key}` → `{token, plaintext, reads_remaining, expires_at}`; consumes one read |
| `GET /api/vault/{token}` | metadata only (no decrypt, no read consumed) |

Error mapping: 404 not found · 410 expired/exhausted · 403 wrong key · 422 invalid · 503 no `DATABASE_URL`.

## Changes

- `kryptos.ciphers.vigenere_encrypt` — inverse of `vigenere_decrypt` over the keyed alphabet (needed for sealing).
- `kryptos.vault` — seal/unseal/peek + typed errors.
- `vault_payloads` added to `db_schema.SCHEMA_STATEMENTS` (created by `kryptos db-init`).
- Router mounted **before** the SPA static mount so `/api/vault/*` resolves.

## Tests

`tests/functional/test_vault.py` uses an in-memory fake of `vault_payloads` to cover, through both the module and the HTTP layer: cipher round-trip, seal→unseal→peek, wrong-key (no read burned), exhaustion, expiry, unknown token, and DB-unavailable.

Verified in Docker: `pytest tests/functional/test_vault.py` → 12 passed; dashboard/public API tests still green; `db_schema` lists `vault_payloads`.

Frontend Vault page is a planned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)