### PR TITLE
Add Vault page to the dashboard SPA

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,9 +7,10 @@ Terminal-aesthetic React SPA over the kryptos FastAPI backend
 
 Shipped pages: **Ops Center** (status, metric cards, top candidates,
 campaign run history with drill-down, ad-hoc decrypt panel), **Decode**
-(K1–K3 animated decoder), and **Database** (Neon connection + per-table
-row counts). The Vault and the SSE live-log tail from
-`docs/analysis/K4-FRONTEND.md` are planned follow-ups.
+(K1–K3 animated decoder), **Database** (Neon connection + per-table row
+counts), and **Vault** (seal a secret under the keyed-alphabet Vigenère,
+share the opaque token, unseal once with the key, and check status). The
+SSE live-log tail from `docs/analysis/K4-FRONTEND.md` is a planned follow-up.
 
 ## Develop (Docker)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,9 @@ import Topbar from "./components/Topbar";
 import OpsCenter from "./pages/OpsCenter";
 import Decode from "./pages/Decode";
 import Database from "./pages/Database";
+import Vault from "./pages/Vault";
 
-type Page = "ops" | "decode" | "database";
+type Page = "ops" | "decode" | "database" | "vault";
 
 export default function App() {
   const [page, setPage] = useState<Page>("ops");
@@ -40,6 +41,9 @@ export default function App() {
         <button className={page === "database" ? "active" : ""} onClick={() => setPage("database")}>
           Database
         </button>
+        <button className={page === "vault" ? "active" : ""} onClick={() => setPage("vault")}>
+          Vault
+        </button>
       </nav>
       <main className="main">
         {error && <div className="banner">API unreachable: {error}</div>}
@@ -51,6 +55,7 @@ export default function App() {
         {page === "ops" && <OpsCenter status={status} />}
         {page === "decode" && <Decode />}
         {page === "database" && <Database status={status} />}
+        {page === "vault" && <Vault />}
       </main>
     </div>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -44,6 +44,31 @@ export interface DecryptResponse {
   plaintext: string;
 }
 
+export interface VaultSealResponse {
+  token: string;
+  cipher: string;
+  max_reads: number;
+  expires_at: string | null;
+}
+
+export interface VaultUnsealResponse {
+  token: string;
+  plaintext: string;
+  reads_remaining: number;
+  expires_at: string | null;
+}
+
+export interface VaultPeekResponse {
+  token: string;
+  cipher: string;
+  status: string;
+  max_reads: number;
+  reads_used: number;
+  reads_remaining: number;
+  sealed_at: string | null;
+  expires_at: string | null;
+}
+
 export class ApiError extends Error {
   status: number;
   constructor(status: number, message: string) {
@@ -86,4 +111,9 @@ export const api = {
   topCandidates: (limit = 20) => getJSON<CandidatesResponse>(`/api/candidates?limit=${limit}`),
   decrypt: (section: string, ciphertext: string, key?: string) =>
     postJSON<DecryptResponse>("/api/decrypt", { section, ciphertext, key: key || null }),
+  vaultSeal: (plaintext: string, key: string, ttl_seconds: number, max_reads: number) =>
+    postJSON<VaultSealResponse>("/api/vault/seal", { plaintext, key, ttl_seconds, max_reads }),
+  vaultUnseal: (token: string, key: string) =>
+    postJSON<VaultUnsealResponse>("/api/vault/unseal", { token, key }),
+  vaultPeek: (token: string) => getJSON<VaultPeekResponse>(`/api/vault/${encodeURIComponent(token)}`),
 };

--- a/frontend/src/pages/Vault.tsx
+++ b/frontend/src/pages/Vault.tsx
@@ -1,0 +1,237 @@
+import { useState } from "react";
+import { ApiError, VaultPeekResponse, VaultSealResponse, VaultUnsealResponse, api } from "../api";
+
+// Vault page (docs/analysis/K4-FRONTEND.md): seal a secret under the keyed-
+// alphabet Vigenère, share the opaque token, and unseal it once with the key.
+// Backend: kryptos.api.vault_routes. Requires DATABASE_URL (else 503).
+
+const TTL_OPTIONS: { label: string; seconds: number }[] = [
+  { label: "1 hour", seconds: 3600 },
+  { label: "1 day", seconds: 86400 },
+  { label: "1 week", seconds: 604800 },
+  { label: "30 days", seconds: 2592000 },
+  { label: "No expiry", seconds: 0 },
+];
+
+function errText(e: unknown): string {
+  if (e instanceof ApiError) {
+    if (e.status === 503) return "Vault unavailable — the server has no DATABASE_URL configured.";
+    return `[${e.status}] ${e.message}`;
+  }
+  return String(e);
+}
+
+function fmtExpiry(iso: string | null): string {
+  return iso ? new Date(iso).toLocaleString() : "never";
+}
+
+function SealPanel() {
+  const [plaintext, setPlaintext] = useState("");
+  const [key, setKey] = useState("");
+  const [ttl, setTtl] = useState(86400);
+  const [maxReads, setMaxReads] = useState(1);
+  const [result, setResult] = useState<VaultSealResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function seal() {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      setResult(await api.vaultSeal(plaintext, key, ttl, maxReads));
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function copyToken() {
+    if (!result) return;
+    navigator.clipboard?.writeText(result.token).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      },
+      () => undefined,
+    );
+  }
+
+  return (
+    <div className="panel">
+      <h2>Seal a secret</h2>
+      <div className="body">
+        <div className="field">
+          <label>Plaintext</label>
+          <textarea
+            rows={3}
+            value={plaintext}
+            onChange={(e) => setPlaintext(e.target.value)}
+            placeholder="The secret to seal"
+          />
+        </div>
+        <div className="field">
+          <label>Key (keyed-alphabet Vigenère)</label>
+          <input value={key} onChange={(e) => setKey(e.target.value)} placeholder="e.g. PALIMPSEST" />
+        </div>
+        <div className="row">
+          <div className="field" style={{ flex: 1 }}>
+            <label>Expires after</label>
+            <select value={ttl} onChange={(e) => setTtl(Number(e.target.value))}>
+              {TTL_OPTIONS.map((o) => (
+                <option key={o.seconds} value={o.seconds}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="field" style={{ flex: 1 }}>
+            <label>Max reads</label>
+            <input
+              type="number"
+              min={1}
+              max={1000}
+              value={maxReads}
+              onChange={(e) => setMaxReads(Math.max(1, Number(e.target.value) || 1))}
+            />
+          </div>
+        </div>
+        <button onClick={seal} disabled={busy || !plaintext || !key}>
+          {busy ? "Sealing…" : "Seal"}
+        </button>
+
+        {error && <div className="result error">{error}</div>}
+        {result && (
+          <div className="result">
+            <div>
+              <strong>Token:</strong> {result.token}{" "}
+              <button onClick={copyToken} style={{ padding: "2px 6px" }}>
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <div className="muted">
+              cipher {result.cipher} · max reads {result.max_reads} · expires{" "}
+              {fmtExpiry(result.expires_at)}
+            </div>
+            <div className="muted">Share the token and key separately — the key is never stored.</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function UnsealPanel() {
+  const [token, setToken] = useState("");
+  const [key, setKey] = useState("");
+  const [result, setResult] = useState<VaultUnsealResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function unseal() {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      setResult(await api.vaultUnseal(token.trim(), key));
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="panel">
+      <h2>Unseal</h2>
+      <div className="body">
+        <div className="field">
+          <label>Token</label>
+          <input value={token} onChange={(e) => setToken(e.target.value)} placeholder="vault token (UUID)" />
+        </div>
+        <div className="field">
+          <label>Key</label>
+          <input value={key} onChange={(e) => setKey(e.target.value)} placeholder="the sealing key" />
+        </div>
+        <button onClick={unseal} disabled={busy || !token || !key}>
+          {busy ? "Unsealing…" : "Unseal (consumes a read)"}
+        </button>
+
+        {error && <div className="result error">{error}</div>}
+        {result && (
+          <div className="result">
+            <div className="plaintext" style={{ marginBottom: 6 }}>
+              {result.plaintext}
+            </div>
+            <div className="muted">
+              {result.reads_remaining} read{result.reads_remaining === 1 ? "" : "s"} remaining · expires{" "}
+              {fmtExpiry(result.expires_at)}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PeekPanel() {
+  const [token, setToken] = useState("");
+  const [result, setResult] = useState<VaultPeekResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function peek() {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      setResult(await api.vaultPeek(token.trim()));
+    } catch (e) {
+      setError(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="panel">
+      <h2>Status</h2>
+      <div className="body">
+        <div className="row" style={{ alignItems: "flex-end" }}>
+          <div className="field" style={{ flex: 1, marginBottom: 0 }}>
+            <label>Token</label>
+            <input value={token} onChange={(e) => setToken(e.target.value)} placeholder="check a token without reading" />
+          </div>
+          <button onClick={peek} disabled={busy || !token}>
+            {busy ? "…" : "Check"}
+          </button>
+        </div>
+
+        {error && <div className="result error">{error}</div>}
+        {result && (
+          <div className="result">
+            <div>
+              <strong>{result.status}</strong>
+            </div>
+            <div className="muted">
+              reads {result.reads_used}/{result.max_reads} · sealed {fmtExpiry(result.sealed_at)} · expires{" "}
+              {fmtExpiry(result.expires_at)}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function Vault() {
+  return (
+    <>
+      <SealPanel />
+      <UnsealPanel />
+      <PeekPanel />
+    </>
+  );
+}


### PR DESCRIPTION
## What

A **Vault** page over the backend shipped in #115 (`kryptos.api.vault_routes`).

- **Seal** — plaintext, key, TTL (1h / 1d / 1w / 30d / no expiry), max-reads → opaque UUID token with a Copy button and a "the key is never stored" reminder.
- **Unseal** — token + key → plaintext + reads remaining (consumes one read).
- **Status** — peek a token without decrypting or burning a read.

Friendly error mapping: `503` → "Vault unavailable — the server has no DATABASE_URL configured"; other `ApiError`s show status + detail (e.g. `403` wrong key, `410` gone, `404` not found).

## Changes

- `frontend/src/pages/Vault.tsx` — three panels (Seal / Unseal / Status).
- `frontend/src/api.ts` — `vaultSeal` / `vaultUnseal` / `vaultPeek` + response types.
- `frontend/src/App.tsx` — Vault nav entry + route.
- `frontend/README.md` — Vault listed among shipped pages.

## Verification

`npm ci && npm run build` (tsc + vite) in `node:22-alpine` → clean build, 28 modules.

Only the SSE live-log tail remains from the K4-FRONTEND plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)