### PR TITLE
feat(api): SSE live-log tail endpoint (GET /api/stream/logs)

### DIFF
--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -406,7 +406,23 @@ is unset (they return `db_enabled: false` with empty results rather than errorin
 | `GET /api/candidates?limit=` | Highest-scoring candidates across all runs |
 | `POST /api/decrypt` | Body `{section, ciphertext, key?}` → `{section, plaintext}`. K1/K2 require `key`; K3 ignores it; unknown section → 422 |
 
-> SSE log streaming (`GET /api/stream/logs`) is a planned follow-up — it needs a log-source design and is not yet implemented.
+### Live log tail (SSE — `kryptos.api.log_stream`)
+
+| Method & path | Purpose |
+|---------------|---------|
+| `GET /api/stream/logs?backlog=&follow=` | Server-Sent Events stream of `kryptos` log records |
+
+`create_app()` installs an idempotent `SSELogHandler` on the `kryptos` logger that
+appends formatted records to a process-wide bounded ring (`LogBuffer`, 1000 lines).
+The endpoint replays the recent backlog, then (when `follow=true`) polls the ring and
+streams new lines as `data:` frames, emitting `: keep-alive` comments every 15s so
+proxies don't drop idle connections.
+
+- `backlog` (default `200`, `0`–`1000`): number of recent lines to replay first.
+- `follow` (default `true`): keep the connection open and stream new lines; `false`
+  replays the backlog and closes. The stream also ends when the client disconnects.
+- Response is `text/event-stream` with `Cache-Control: no-cache` and
+  `X-Accel-Buffering: no` (disables proxy buffering so events flush immediately).
 
 ### Vault (`kryptos.api.vault_routes` / `kryptos.vault`)
 

--- a/src/kryptos/api/app.py
+++ b/src/kryptos/api/app.py
@@ -7,10 +7,12 @@ import os
 from dataclasses import asdict
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 from kryptos.api.dashboard import create_dashboard_router
+from kryptos.api.log_stream import install_log_streaming, log_event_stream
 from kryptos.api.vault_routes import create_vault_router
 from kryptos.rag.index import ArtifactIndex
 
@@ -45,6 +47,9 @@ def create_app(index: ArtifactIndex | None = None) -> FastAPI:
     index = index if index is not None else ArtifactIndex()
     index.load()
 
+    # Capture kryptos log records into the ring buffer the SSE tail streams.
+    install_log_streaming()
+
     app = FastAPI(title="Kryptos API", version="0.1.0")
     app.include_router(create_dashboard_router())
     app.include_router(create_vault_router())
@@ -70,6 +75,17 @@ def create_app(index: ArtifactIndex | None = None) -> FastAPI:
             )
         results = index.search(q, k=k)
         return {"query": q, "results": [asdict(r) for r in results]}
+
+    @app.get("/api/stream/logs")
+    async def stream_logs(
+        request: Request,
+        backlog: int = Query(200, ge=0, le=1000),
+        follow: bool = Query(True),
+    ) -> StreamingResponse:
+        stream = log_event_stream(request.is_disconnected, backlog=backlog, follow=follow)
+        # X-Accel-Buffering disables proxy buffering so events flush immediately.
+        headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+        return StreamingResponse(stream, media_type="text/event-stream", headers=headers)
 
     # Mount the built SPA LAST so API routes (/api/*, /health) always win.
     # html=True serves index.html for unknown paths (client-side routing).

--- a/src/kryptos/api/log_stream.py
+++ b/src/kryptos/api/log_stream.py
@@ -1,0 +1,149 @@
+"""Server-Sent Events log tail for the dashboard.
+
+A process-wide :class:`LogBuffer` (a bounded, thread-safe ring) is fed by a
+:class:`logging.Handler` attached to the ``kryptos`` logger. The SSE endpoint
+replays the recent backlog and then polls the buffer for new lines, so log
+records emitted from worker threads need no asyncio/thread coordination — the
+generator just reads the latest sequence numbers on each tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from collections import deque
+from typing import AsyncIterator
+
+DEFAULT_CAPACITY = 1000
+_DEFAULT_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+_HANDLER_MARKER = "_kryptos_sse_handler"
+
+
+class LogBuffer:
+    """Bounded ring of formatted log lines, each tagged with a monotonic seq."""
+
+    def __init__(self, capacity: int = DEFAULT_CAPACITY) -> None:
+        self._buf: deque[tuple[int, str]] = deque(maxlen=capacity)
+        self._seq = 0
+        self._lock = threading.Lock()
+
+    def append(self, line: str) -> int:
+        with self._lock:
+            self._seq += 1
+            self._buf.append((self._seq, line))
+            return self._seq
+
+    def latest_seq(self) -> int:
+        with self._lock:
+            return self._seq
+
+    def tail(self, count: int) -> list[tuple[int, str]]:
+        """Return up to ``count`` most-recent entries (oldest first)."""
+        with self._lock:
+            items = list(self._buf)
+        return items[-count:] if count > 0 else []
+
+    def since(self, seq: int) -> list[tuple[int, str]]:
+        """Return entries with sequence strictly greater than ``seq``."""
+        with self._lock:
+            return [(s, line) for (s, line) in self._buf if s > seq]
+
+
+# Process-wide buffer shared by the handler and the endpoint.
+LOG_BUFFER = LogBuffer()
+
+
+class SSELogHandler(logging.Handler):
+    """Logging handler that appends formatted records to a :class:`LogBuffer`."""
+
+    def __init__(self, buffer: LogBuffer, level: int = logging.INFO) -> None:
+        super().__init__(level=level)
+        self.buffer = buffer
+        self.setFormatter(logging.Formatter(_DEFAULT_FORMAT))
+        setattr(self, _HANDLER_MARKER, True)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self.buffer.append(self.format(record))
+        except Exception:  # noqa: BLE001 - logging must never raise
+            self.handleError(record)
+
+
+def install_log_streaming(logger_name: str = "kryptos", buffer: LogBuffer | None = None) -> SSELogHandler:
+    """Attach an :class:`SSELogHandler` to ``logger_name`` (idempotent).
+
+    Returns the handler (existing or newly created). The logger level is lowered
+    to INFO if it was higher so records actually reach the handler.
+    """
+    target = buffer or LOG_BUFFER
+    logger = logging.getLogger(logger_name)
+    for h in logger.handlers:
+        if getattr(h, _HANDLER_MARKER, False):
+            return h  # type: ignore[return-value]
+    handler = SSELogHandler(target)
+    logger.addHandler(handler)
+    if logger.level == logging.NOTSET or logger.level > logging.INFO:
+        logger.setLevel(logging.INFO)
+    return handler
+
+
+def _format_sse(line: str) -> str:
+    """Encode a (possibly multi-line) log line as one SSE ``data:`` event."""
+    body = "\n".join(f"data: {part}" for part in line.splitlines() or [""])
+    return f"{body}\n\n"
+
+
+async def log_event_stream(
+    is_disconnected,
+    backlog: int = 200,
+    follow: bool = True,
+    buffer: LogBuffer | None = None,
+    poll_interval: float = 0.5,
+    heartbeat_interval: float = 15.0,
+) -> AsyncIterator[str]:
+    """Yield SSE frames: the recent backlog, then (if ``follow``) live lines.
+
+    ``is_disconnected`` is an awaitable returning True when the client has gone
+    away (e.g. ``starlette.Request.is_disconnected``). Heartbeat comments keep
+    proxies from closing an idle connection.
+    """
+    buf = buffer or LOG_BUFFER
+
+    last_seq = 0
+    for seq, line in buf.tail(backlog):
+        last_seq = seq
+        yield _format_sse(line)
+
+    if not follow:
+        return
+
+    # Without backlog, start from the current tip so we only stream new lines.
+    if last_seq == 0:
+        last_seq = buf.latest_seq()
+
+    since_heartbeat = 0.0
+    while True:
+        if await is_disconnected():
+            return
+        new_entries = buf.since(last_seq)
+        if new_entries:
+            for seq, line in new_entries:
+                last_seq = seq
+                yield _format_sse(line)
+            since_heartbeat = 0.0
+        else:
+            since_heartbeat += poll_interval
+            if since_heartbeat >= heartbeat_interval:
+                since_heartbeat = 0.0
+                yield ": keep-alive\n\n"
+        await asyncio.sleep(poll_interval)
+
+
+__all__ = [
+    "LogBuffer",
+    "LOG_BUFFER",
+    "SSELogHandler",
+    "install_log_streaming",
+    "log_event_stream",
+]

--- a/tests/functional/test_log_stream.py
+++ b/tests/functional/test_log_stream.py
@@ -1,0 +1,123 @@
+"""Tests for the SSE log tail: ring buffer, handler, and event stream."""
+
+import asyncio
+import logging
+
+from fastapi.testclient import TestClient
+
+from kryptos.api import log_stream
+from kryptos.api.app import create_app
+from kryptos.api.log_stream import LogBuffer, SSELogHandler, _format_sse, install_log_streaming, log_event_stream
+from kryptos.rag.index import ArtifactIndex
+
+
+async def _collect(agen, limit=100):
+    out = []
+    async for frame in agen:
+        out.append(frame)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --- LogBuffer ----------------------------------------------------------------
+
+
+def test_log_buffer_tail_and_since():
+    buf = LogBuffer(capacity=3)
+    for line in ["a", "b", "c", "d"]:
+        buf.append(line)
+    # Capacity 3 -> oldest ("a") evicted.
+    assert [line for _seq, line in buf.tail(10)] == ["b", "c", "d"]
+    assert [line for _seq, line in buf.tail(2)] == ["c", "d"]
+
+    seq_c = buf.tail(10)[1][0]
+    assert [line for _seq, line in buf.since(seq_c)] == ["d"]
+    assert buf.since(buf.latest_seq()) == []
+
+
+# --- Handler ------------------------------------------------------------------
+
+
+def test_handler_captures_records():
+    buf = LogBuffer()
+    handler = SSELogHandler(buf)
+    logger = logging.getLogger("kryptos.test.capture")
+    logger.handlers = [handler]
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    logger.info("hello %s", "world")
+    logger.debug("not captured")  # below handler level
+
+    lines = [line for _seq, line in buf.tail(10)]
+    assert any("hello world" in ln for ln in lines)
+    assert not any("not captured" in ln for ln in lines)
+
+
+def test_install_is_idempotent():
+    name = "kryptos.test.install"
+    h1 = install_log_streaming(logger_name=name, buffer=LogBuffer())
+    h2 = install_log_streaming(logger_name=name, buffer=LogBuffer())
+    assert h1 is h2
+    logger = logging.getLogger(name)
+    assert sum(isinstance(h, SSELogHandler) for h in logger.handlers) == 1
+
+
+# --- SSE formatting -----------------------------------------------------------
+
+
+def test_format_sse_multiline():
+    frame = _format_sse("line1\nline2")
+    assert frame == "data: line1\ndata: line2\n\n"
+
+
+# --- Event stream -------------------------------------------------------------
+
+
+def test_stream_replays_backlog_and_stops():
+    buf = LogBuffer()
+    for line in ["one", "two", "three"]:
+        buf.append(line)
+
+    async def never_disconnected():
+        return False
+
+    frames = _run(_collect(log_event_stream(never_disconnected, backlog=10, follow=False, buffer=buf)))
+    assert frames == [_format_sse(x) for x in ["one", "two", "three"]]
+
+
+def test_stream_stops_on_disconnect():
+    buf = LogBuffer()
+    buf.append("only")
+
+    async def disconnected():
+        return True
+
+    # follow=True but the client is already gone: replay backlog, then return
+    # at the first disconnect check rather than looping forever.
+    frames = _run(
+        asyncio.wait_for(
+            _collect(log_event_stream(disconnected, backlog=10, follow=True, buffer=buf, poll_interval=0.01)),
+            timeout=2.0,
+        )
+    )
+    assert frames == [_format_sse("only")]
+
+
+# --- HTTP layer ---------------------------------------------------------------
+
+
+def test_http_stream_backlog(tmp_path):
+    # The endpoint uses the module-global LOG_BUFFER; seed it then read backlog.
+    log_stream.LOG_BUFFER.append("CAMPAIGN started")
+    client = TestClient(create_app(index=ArtifactIndex(index_dir=tmp_path / "index")))
+
+    resp = client.get("/api/stream/logs", params={"follow": "false", "backlog": "1000"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert "data: CAMPAIGN started" in resp.text


### PR DESCRIPTION
## Summary

Adds the SSE live-log tail endpoint the Ops Center dashboard needs to stream campaign log lines in real time. This is the **backend half** of the SSE work; the frontend `LogTail` EventSource component follows in a separate PR.

`GET /api/stream/logs?backlog=&follow=` streams `kryptos` log records as Server-Sent Events.

## What's here

- **`src/kryptos/api/log_stream.py`** — process-wide bounded `LogBuffer` ring (1000 lines, thread-safe, monotonic seq tags) fed by an idempotent `SSELogHandler` attached to the `kryptos` logger. `log_event_stream()` replays the recent backlog, then (when `follow=true`) polls the ring for new lines, emitting `: keep-alive` comments every 15s and terminating on client disconnect. No asyncio/thread coordination needed — worker-thread log records just land in the ring and the generator reads the latest seqs each tick.
- **`src/kryptos/api/app.py`** — `install_log_streaming()` wired into `create_app()`; `GET /api/stream/logs` with `backlog` (0–1000) and `follow` query params, returned as `text/event-stream` with `Cache-Control: no-cache` and `X-Accel-Buffering: no` (flush through proxies).
- **`tests/functional/test_log_stream.py`** — covers the ring (tail/since/eviction), handler capture + idempotent install, multi-line SSE framing, backlog replay, disconnect-stop, and the HTTP layer. Fast and deterministic (run in the `not slow` CI gate).
- **`docs/reference/API_REFERENCE.md`** — documents the implemented endpoint (was previously marked "not yet implemented").

## Testing

- New SSE tests: **7 passed** in ~2s (Docker, `python:3.11-slim` deps image).
- Broader functional+smoke `not slow` suite green aside from pre-existing `artifacts/` write-permission failures specific to the read-only host mount (all pass as root / in CI's writable checkout) — none touch the SSE module.

Tracks task #30 (SSE live-log tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)