### PR TITLE
feat(frontend): live log tail on Ops Center via SSE

### DIFF
--- a/frontend/src/components/LogTail.tsx
+++ b/frontend/src/components/LogTail.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from "react";
+
+type ConnState = "connecting" | "live" | "stopped" | "error";
+
+const MAX_LINES = 1000;
+const BACKLOG = 200;
+
+// Live tail of the kryptos backend log via the SSE endpoint
+// (GET /api/stream/logs, src/kryptos/api/log_stream.py). EventSource auto-
+// reconnects on transient drops; the heartbeat comments the server sends keep
+// idle proxies from closing the stream.
+export default function LogTail() {
+  const [lines, setLines] = useState<string[]>([]);
+  const [state, setState] = useState<ConnState>("stopped");
+  const [running, setRunning] = useState(true);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const esRef = useRef<EventSource | null>(null);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!running) {
+      esRef.current?.close();
+      esRef.current = null;
+      setState("stopped");
+      return;
+    }
+
+    setState("connecting");
+    const es = new EventSource(`/api/stream/logs?backlog=${BACKLOG}&follow=true`);
+    esRef.current = es;
+
+    es.onopen = () => setState("live");
+    es.onmessage = (e) => {
+      setLines((prev) => {
+        const next = prev.concat(e.data.split("\n"));
+        return next.length > MAX_LINES ? next.slice(next.length - MAX_LINES) : next;
+      });
+    };
+    es.onerror = () => {
+      // EventSource retries on its own; surface the gap but keep the connection.
+      setState("error");
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, [running]);
+
+  // Pin to the newest line as it arrives, unless the user opted out.
+  useEffect(() => {
+    if (autoScroll && bodyRef.current) {
+      bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+    }
+  }, [lines, autoScroll]);
+
+  const label =
+    state === "live"
+      ? "● live"
+      : state === "connecting"
+        ? "○ connecting…"
+        : state === "error"
+          ? "● reconnecting…"
+          : "○ stopped";
+  const labelClass = state === "error" ? "error" : state === "live" ? "" : "muted";
+
+  return (
+    <div className="logtail">
+      <div className="logtail-bar">
+        <span className={labelClass}>{label}</span>
+        <span className="muted">{lines.length} lines</span>
+        <label className="logtail-toggle">
+          <input type="checkbox" checked={autoScroll} onChange={(e) => setAutoScroll(e.target.checked)} />
+          auto-scroll
+        </label>
+        <button type="button" onClick={() => setLines([])} disabled={lines.length === 0}>
+          Clear
+        </button>
+        <button type="button" onClick={() => setRunning((r) => !r)}>
+          {running ? "Pause" : "Resume"}
+        </button>
+      </div>
+      <div className="logtail-body" ref={bodyRef}>
+        {lines.length === 0 ? (
+          <div className="muted">No log lines yet.</div>
+        ) : (
+          lines.map((line, i) => (
+            <div key={i} className="logtail-line">
+              {line}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/OpsCenter.tsx
+++ b/frontend/src/pages/OpsCenter.tsx
@@ -4,6 +4,7 @@ import MetricCards from "../components/MetricCards";
 import RunsTable from "../components/RunsTable";
 import CandidatesTable from "../components/CandidatesTable";
 import DecryptPanel from "../components/DecryptPanel";
+import LogTail from "../components/LogTail";
 
 export default function OpsCenter({ status }: { status: StatusResponse | null }) {
   const [runs, setRuns] = useState<Run[]>([]);
@@ -51,6 +52,13 @@ export default function OpsCenter({ status }: { status: StatusResponse | null })
         <h2>Top candidates (all runs)</h2>
         <div className="body">
           <CandidatesTable candidates={topCandidates} />
+        </div>
+      </div>
+
+      <div className="panel">
+        <h2>Live log</h2>
+        <div className="body">
+          <LogTail />
         </div>
       </div>
 

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -268,3 +268,41 @@ button:disabled {
   color: var(--warning);
   font-size: 12px;
 }
+
+.logtail-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+  font-size: 12px;
+}
+
+.logtail-bar .logtail-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.logtail-bar button {
+  font-size: 12px;
+  padding: 2px 10px;
+}
+
+.logtail-body {
+  height: 280px;
+  overflow-y: auto;
+  padding: 8px;
+  border: 0.5px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  white-space: pre-wrap;
+  word-break: break-all;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.logtail-line {
+  border-bottom: 0.5px solid rgba(29, 158, 117, 0.08);
+  padding: 1px 0;
+}


### PR DESCRIPTION
## Summary

Frontend half of the SSE live-log tail (task #30). Surfaces the backend `GET /api/stream/logs` endpoint (landed in #118) as a live, terminal-style log pane on the **Ops Center** page.

## What's here

- **`frontend/src/components/LogTail.tsx`** — opens `EventSource("/api/stream/logs?backlog=200&follow=true")`. The browser auto-reconnects on transient drops and the server's heartbeat comments keep idle proxies from closing the stream. UI shows connection status (live / connecting / reconnecting / stopped), retained line count, an auto-scroll toggle, **Clear**, and **Pause/Resume** (closes/reopens the stream). Retained lines are capped at 1000 to bound DOM growth.
- **`frontend/src/theme.css`** — `.logtail-*` styles in the existing terminal palette.
- **`frontend/src/pages/OpsCenter.tsx`** — new "Live log" panel between Top candidates and Campaign runs.

## Testing

- `npm ci && npm run build` (`tsc && vite build`) in `node:22-alpine` — typecheck clean, production bundle built (exit 0). This mirrors the CI `frontend` job exactly.

With this merged, both halves of task #30 are complete, finishing the planned dashboard surface (Ops / Decode / Database / Vault + live log + static serving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)