### PR TITLE
docs: reconcile ROADMAP/TASKS completed work into FEATURES

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,7 +4,7 @@
 > Cryptographic research toolkit for solving the K4 cipher puzzle
 
 ---
-**Last Updated:** 2026-06-10
+**Last Updated:** 2026-06-17
 ---
 
 
@@ -52,6 +52,10 @@
 - **Keystream Validator**: Per-position shift computation and simultaneous 4-crib validation (`keystream_validator.py`)
 - **Eureka Capture Protocol**: Raises `EurekaSignal` on simultaneous 4-crib match; writes breakthrough snapshot; wired into `CompositeChainExecutor` (`eureka.py`)
 - **Keyed Alphabet Realignment**: Tests KRYPTOS, PALIMPSEST, ABSCISSA alphabets against confirmed crib positions (`vigenere_key_recovery.check_keyed_alphabet_realignment`); null result
+- **Quagmire I–IV Solver + Sweep**: Canonical encrypt/decrypt for all four Quagmire variants (ground-truth verified against K1/K2); 6,240-combination K4 sweep with positional crib gating + Eureka protocol (`k4.quagmire`, `k4.quagmire_sweep`); null result
+- **Physical-Grid Tableau Walk**: Walks the 26×26 KRYPTOS Vigenère tableau along 108 geometric routes into the Quagmire III solver against K4 (`k4.physical_grid`); null result
+- **Berlin Clock Attack Suite**: Clock→Hill 2×2 invertibility pre-filter, 4-char clock→Vigenère with NORTHEAST anchor, non-standard sub-row encodings, and lamp-count transposition widths (`k4.clock_hill_attack`, `k4.clock_subrow_attack`); all null result
+- **Beaufort K4 Sweep**: Systematic reciprocal-Beaufort pass over KRYPTOS/PALIMPSEST/BERLIN/CLOCK/ABSCISSA keys (`k4.beaufort_sweep`); null result
 
 ### ⚙️ Pipeline Architecture
 
@@ -112,6 +116,31 @@
 
 ---
 
+## 🖥️ Dashboard, Web UI & HTTP API
+
+### React SPA (terminal aesthetic)
+
+- **Ops Center**: Live campaign monitoring, agent status row, top fused candidates, run history with drill-down, and an ad-hoc decrypt panel
+- **K1–K3 Animated Decoder**: Step-by-step visual explainer of how each solved section was encrypted and cracked
+- **Database Admin**: Neon connection status and per-table row counts
+- **Vault**: Seal a secret under the keyed-alphabet Vigenère, share an opaque token, unseal once with the key, and check status — TTL and read-count enforced server-side
+- **Single-container delivery**: FastAPI serves the built `frontend/dist` bundle via `StaticFiles(html=True)`; the root `Dockerfile` builds the SPA in a `node:22-alpine` stage and ships it alongside the API (`KRYPTOS_FRONTEND_DIST`)
+- **Stack**: Vite + React 18 + TypeScript, no runtime UI framework
+
+### HTTP API (FastAPI)
+
+- **Dashboard endpoints**: `GET /api/status`, `GET /api/runs`, `GET /api/runs/{id}/candidates`, `GET /api/candidates`, `POST /api/decrypt`
+- **Vault endpoints**: `POST /api/vault/seal`, `POST /api/vault/unseal`, `GET /api/vault/{token}` (503/404/410/403 error mapping for unavailable/missing/gone/wrong-key)
+- **RAG endpoints**: `GET /api/rag/status`, `POST /api/rag/reindex`, `GET /api/rag/search`
+- **Health**: `GET /health`
+
+### Persistence
+
+- **`campaign_runs` + `candidates` tables**: Best-effort write path persists live campaign runs and their candidates to Neon (graceful no-op without `DATABASE_URL`)
+- **`vault_payloads` table**: Token-addressed ciphertext with verifier, max-reads, and expiry; atomic read-decrement guarantees one-shot semantics
+
+---
+
 ## Development Tools
 
 - **CLI Interface**: 18 subcommands covering decryption, tuning, provenance, autonomous runs, and reporting
@@ -139,25 +168,16 @@
 
 ## 🚀 Planned & Upcoming
 
-### 🔑 K4 Untested Attack Vectors
-- **Clock → Hill 2×2 pre-filter**: Use clock state lamp values as a Hill matrix key (~100 invertible states to test)
-- **4-char clock key → Vigenère**: Derive 4-char keys from clock states, test with NORTHEAST positional anchor
-- **Non-standard clock encodings**: Sub-row variants (hour-only, minute-only, row sums)
-- **Clock lamp counts as transposition widths**: Use lamp values as column widths, not Vigenère shifts
-- **Beaufort cipher sweep**: `kryptos.k4.beaufort` implemented; no systematic K4 sweep run yet
+> The five untested K4 attack vectors, the dashboard pages (Ops Center, K1–K3 Decoder,
+> Database, Vault), the REST API, Neon candidate/run storage, and the K3 double-rotation
+> Monte Carlo have all shipped — see the sections above. What remains:
 
 ### 🖥️ Dashboard & UI
-- **Ops Center Dashboard**: Live campaign monitoring, agent status, top candidates, letter frequency chart
-- **K1–K3 Animated Decoder**: Step-by-step visual explainer of each solved section
-- **K4 Attack Dashboard**: Real-time pipeline progress, scoring breakdowns, evidence artifacts
-- **Vault**: Demo encrypt/decrypt interface for all supported ciphers
-- **FastAPI + React SPA**: Single-container deployment via `docker compose up`
-- See `docs/analysis/K4-FRONTEND.md` for full spec (note: SQLite schema in that doc is superseded by Neon)
+- **SSE live-log tail**: `GET /api/stream/logs` + an Ops Center `LogTail` component (backend implemented on the `sse-log-tail` branch; frontend wiring pending)
+- **Dedicated K4 Attack Dashboard**: Visual fingerprint map of attack vectors — plausible vs. covered vs. unknown (live progress, scoring, and artifact lookup are already covered by Ops Center, Database, and RAG search)
 
 ### 📡 API & Data
-- **REST API**: Endpoints for decryption, candidate queries, run history, live log streaming (SSE)
 - **`strategy_kb` write path**: Automate writing successful/failed strategies back to the Neon table
-- **K3 double-transposition Monte Carlo**: Full double-rotational K3 algorithm not yet validated statistically
 
 ### 🧠 AI/ML & Community
 - **LLM-Driven Hypothesis Generation**: Use LLMs to propose new attacks and scoring strategies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # 🗺️ Kryptos Roadmap
 
-Last Updated: 2026-06-01
+Last Updated: 2026-06-17
 Next Review: 2026-07-01
 ---
 
@@ -28,16 +28,18 @@ Next Review: 2026-07-01
 
 ### Phase 2 — Dashboard & UI
 
-- [ ] See `docs/analysis/K4-FRONTEND.md` for full spec. Stack: FastAPI + React SPA, single Docker container, Neon DB (not SQLite — the spec's schema is superseded by existing Neon tables).
-- [ ] **Ops Center** — live campaign monitoring, agent status row (SPY/OPS/Q), top fused candidates table, letter frequency chart, live log tail via SSE
-- [ ] **K1–K3 Animated Decoder** — step-by-step visual explainer of how each solved section was encrypted and cracked
-- [ ] **K4 Attack Dashboard** — real-time pipeline progress, scoring breakdowns, evidence artifact viewer
-- [ ] **Vault** — demo encrypt/decrypt interface for all supported ciphers with TTL and read-count enforcement
+> Stack shipped as specified: FastAPI + React SPA in a single multistage Docker container, served from `frontend/dist` by `create_app()`, backed by Neon. See `docs/analysis/K4-FRONTEND.md`.
+
+- [x] **Ops Center** — live campaign monitoring, agent status row, top fused candidates table, run history with drill-down, ad-hoc decrypt panel (#100). Live log tail via SSE is the remaining piece (see Phase 3).
+- [x] **K1–K3 Animated Decoder** — step-by-step visual explainer of how each solved section was encrypted and cracked (#102)
+- [x] **Database admin page** — Neon connection status + per-table row counts (#104)
+- [x] **Vault** — seal/unseal/peek encrypt/decrypt interface (keyed-alphabet Vigenère) with TTL and read-count enforcement (#115 backend, #116 frontend)
+- [ ] **K4 Attack Dashboard** — dedicated real-time pipeline-progress + evidence-artifact viewer (most is covered by Ops Center, Database, and RAG search; a standalone attack-vector fingerprint view remains)
 
 ### Phase 3 — API
-- [ ] **REST API** (`/api/status`, `/api/candidates`, `/api/runs`, `/api/stream/logs`, `POST /api/decrypt`)
+- [x] **REST dashboard API** — `/api/status`, `/api/runs`, `/api/runs/{id}/candidates`, `/api/candidates`, `POST /api/decrypt` (#99); turbovec RAG search at `/api/rag/*` (#113). `/api/stream/logs` (SSE) is in flight on a separate branch.
 - [ ] **`strategy_kb` write path** — automate writing successful/failed strategies from `OpsStrategicDirector` back to Neon
-- [ ] **Candidate & run storage** — `candidates` and `campaign_runs` tables in Neon (currently file-based under `artifacts/`)
+- [x] **Candidate & run storage** — `candidates` and `campaign_runs` tables in Neon, persisted best-effort from campaigns (#98)
 
 ### Phase 4 — Validation & hardening
 - [x] **K3 double-transposition Monte Carlo** — `kryptos.k3.double_rotation_solver` generalizes K3's two-stage 90cw rotation to all divisor-width/rotation-type pairs; brute-force solver exactly recovers K3's plaintext as the top candidate. Monte Carlo across random parameter pairs: 75% best-of-top-10 success (`tests/e2e/test_k3_double_rotation_monte_carlo.py`)

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-06-12
+Last Updated: 2026-06-17
 
 
 ## Todo
@@ -8,15 +8,11 @@ Last Updated: 2026-06-12
 # Q1 2027: Final Push & Post-Solution Analysis
 
 ### Phase 1: Dashboard & UI
-- Implement real-time campaign monitoring dashboard (CLI/GUI)
-- Build K1–K3 Decoder: input ciphertext + key → annotated plaintext, with encoding/hacking instructions
-- Develop K4 Attack Dashboard: live campaign progress, scoring breakdowns, evidence artifact viewer, visual fingerprint map of attack vectors plausible vs. covered vs. unknown
-
-- Create Vault: demo encrypt/decrypt interface for all supported ciphers
+- Develop dedicated K4 Attack Dashboard: visual fingerprint map of attack vectors plausible vs. covered vs. unknown (Ops Center, Database, and RAG search already cover live progress, scoring, and artifact lookup)
+- Wire the SSE live-log tail (`/api/stream/logs`) into the Ops Center page (backend in flight on a separate branch)
 
 ### Phase 2: Data & API
-- Integrate database (e.g., neon) for storing keys, plaintexts, attempts, provenance
-- Develop API endpoints for querying and managing cryptanalysis data
+- `strategy_kb` write path — automate persisting successful/failed strategies from `OpsStrategicDirector` back to Neon
 
 ### Phase 3: Post-Solution Analysis
 - Analyze and document attack path, key insights, and lessons learned after solution
@@ -30,7 +26,18 @@ Last Updated: 2026-06-12
 
 ## In Progress
 
+- [ ] **SSE live-log tail** — `GET /api/stream/logs` (StreamingResponse, `text/event-stream`) backed by a thread-safe ring buffer fed by a `kryptos`-logger handler, plus a frontend `LogTail` EventSource component on Ops Center. Backend implemented and unit-tested on the `sse-log-tail` branch.
+
 ## Done
+
+### Dashboard, REST API & Web UI (Q1 2027 Phases 1–2)
+
+- [x] **FastAPI dashboard endpoints** — `/api/status`, `/api/runs`, `/api/runs/{id}/candidates`, `/api/candidates`, `POST /api/decrypt` over the `create_app()` factory (#99).
+- [x] **Neon persistence for campaigns** — `campaign_runs` + `candidates` tables (`db_schema.py`) with best-effort write path from live campaigns (#93 schema/`kryptos db-init`, #98 persistence).
+- [x] **React + Vite + TypeScript SPA** — terminal-aesthetic dashboard scaffold with Ops Center (#100), K1–K3 animated decoder (#102), Database admin page (#104), and Vault page (#116). Vite bumped 5→8 to clear esbuild/vite CVEs (#103).
+- [x] **Kryptos Vault** — seal/unseal/peek API + `vault_payloads` table; keyed-alphabet Vigenère with TTL and read-count enforcement, key never stored, wrong-key attempts don't burn a read (#115 backend, #116 frontend).
+- [x] **Single-container delivery** — FastAPI serves the built SPA from `frontend/dist` via `StaticFiles(html=True)`; root `Dockerfile` builds the bundle in a `node:22-alpine` stage and ships it with the API (#114).
+- [x] **turbovec RAG behind the FastAPI app** — `/api/rag/*` semantic search over `artifacts/` embedded into the dashboard service (#113, #87).
 
 ### SA transposition seeding + early-crib locking verification
 


### PR DESCRIPTION
## Summary
- Moves shipped Q1-2027 dashboard/API work and K4 attack sweeps from planning docs into FEATURES.md as concrete shipped capabilities
- ROADMAP: marks Phase 2 (Ops Center, K1–K3 Decoder, Database, Vault) and Phase 3 (REST API, candidate/run storage) as done with PR refs
- TASKS: moves delivered Dashboard/Data-&-API items from Todo to Done; records SSE log tail as In Progress
- FEATURES: adds "Dashboard, Web UI & HTTP API" section and shipped K4 attack modules (Quagmire, physical-grid, Berlin Clock suite, Beaufort sweep); prunes Planned to remaining work only

## Test plan
- [ ] FEATURES.md, ROADMAP.md, TASKS.md all render correctly
- [ ] Docs-only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)