### PR TITLE
feat: ops director strategy KB persistence and recording

### DIFF
--- a/src/kryptos/agents/ops_director.py
+++ b/src/kryptos/agents/ops_director.py
@@ -90,17 +90,18 @@ class OpsStrategicDirector:
         decision = self._make_strategic_decision(situation)
         self.decision_history.append(decision)
         self._save_decision(decision)
+        self._record_strategy_from_decision(decision)
 
         return decision
 
     def synthesize_agent_insights(self, insights: list[AgentInsight]) -> dict[str, Any]:
-        by_category = {}
+        by_category: dict[str, list[AgentInsight]] = {}
         for insight in insights:
             if insight.category not in by_category:
                 by_category[insight.category] = []
             by_category[insight.category].append(insight)
 
-        synthesis = {
+        synthesis: dict[str, Any] = {
             "timestamp": datetime.now(),
             "insight_count": len(insights),
             "categories": list(by_category.keys()),
@@ -109,8 +110,8 @@ class OpsStrategicDirector:
             "confidence": 0.0,
         }
 
-        linguistic_insights = by_category.get("linguistic", [])
-        pattern_insights = by_category.get("pattern", [])
+        linguistic_insights: list[AgentInsight] = by_category.get("linguistic", [])
+        pattern_insights: list[AgentInsight] = by_category.get("pattern", [])
 
         if len(linguistic_insights) >= 2 or (linguistic_insights and pattern_insights):
             synthesis["key_findings"].append(
@@ -125,7 +126,7 @@ class OpsStrategicDirector:
                 "Focus on linguistically-validated candidates - they score higher on multiple metrics",
             )
 
-        intel_insights = by_category.get("external_intel", [])
+        intel_insights: list[AgentInsight] = by_category.get("external_intel", [])
         if intel_insights:
             new_cribs = [i.metadata.get("cribs", []) for i in intel_insights if "cribs" in i.metadata]
             if new_cribs:
@@ -447,14 +448,26 @@ class OpsStrategicDirector:
     def _load_strategy_kb(self) -> dict[str, Any]:
         try:
             from kryptos.db import get_conn
+
             with get_conn() as conn:
                 cur = conn.cursor()
-                cur.execute("SELECT category, description, attack_type, confidence, metadata FROM strategy_kb ORDER BY id")
+                cur.execute(
+                    "SELECT category, description, attack_type, confidence, metadata FROM strategy_kb ORDER BY id"
+                )
                 rows = cur.fetchall()
             kb: dict[str, Any] = {"successful_strategies": [], "failed_strategies": [], "lessons_learned": []}
-            category_map = {"successful": "successful_strategies", "failed": "failed_strategies", "lesson": "lessons_learned"}
+            category_map = {
+                "successful": "successful_strategies",
+                "failed": "failed_strategies",
+                "lesson": "lessons_learned",
+            }
             for category, description, attack_type, confidence, metadata in rows:
-                entry = {"description": description, "attack_type": attack_type, "confidence": confidence, "metadata": metadata or {}}
+                entry = {
+                    "description": description,
+                    "attack_type": attack_type,
+                    "confidence": confidence,
+                    "metadata": metadata or {},
+                }
                 kb[category_map[category]].append(entry)
             return kb
         except Exception:
@@ -467,9 +480,95 @@ class OpsStrategicDirector:
                     pass
             return {"successful_strategies": [], "failed_strategies": [], "lessons_learned": []}
 
+    # Maps a strategy_kb category to the in-memory KB list and back. Categories
+    # match the strategy_kb CHECK constraint (kryptos.db_schema).
+    _KB_CATEGORY_TO_LIST = {
+        "successful": "successful_strategies",
+        "failed": "failed_strategies",
+        "lesson": "lessons_learned",
+    }
+
+    # Which strategic actions are worth recording as durable learning, and the
+    # strategy_kb category each maps to. CONTINUE/REDUCE are steady-state and
+    # produce no entry.
+    _ACTION_TO_CATEGORY = {
+        StrategyAction.BOOST: "successful",
+        StrategyAction.START_NEW: "lesson",
+        StrategyAction.PIVOT: "failed",
+        StrategyAction.STOP: "failed",
+        StrategyAction.EMERGENCY_STOP: "failed",
+    }
+
+    def record_strategy(
+        self,
+        category: str,
+        description: str,
+        attack_type: str | None = None,
+        confidence: float | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Record an accumulated strategy/lesson in the KB (memory + Neon).
+
+        ``category`` is one of ``successful``, ``failed``, ``lesson``. The entry
+        is appended to the in-memory ``strategy_kb`` immediately and persisted to
+        the ``strategy_kb`` Neon table; if the DB is unavailable it falls back to
+        a JSONL file so the learning is never lost. Mirrors ``_save_decision``.
+        """
+        list_key = self._KB_CATEGORY_TO_LIST.get(category)
+        if list_key is None:
+            raise ValueError(f"category must be one of {tuple(self._KB_CATEGORY_TO_LIST)}, got {category!r}")
+
+        entry = {
+            "description": description,
+            "attack_type": attack_type,
+            "confidence": confidence,
+            "metadata": metadata or {},
+        }
+        if list_key not in self.strategy_kb:
+            self.strategy_kb[list_key] = []
+        self.strategy_kb[list_key].append(entry)
+
+        from kryptos import persistence
+
+        strategy_id = persistence.persist_strategy(
+            category, description, attack_type=attack_type, confidence=confidence, metadata=metadata
+        )
+        if strategy_id is None:
+            kb_file = self.cache_dir / "strategy_kb_writes.jsonl"
+            with open(kb_file, "a") as f:
+                f.write(json.dumps({"category": category, **entry}, default=str) + "\n")
+
+    def _record_strategy_from_decision(self, decision: StrategicDecision) -> None:
+        """Translate a strategic decision into a durable strategy_kb entry.
+
+        PIVOT/STOP record the abandoned attack as a failed strategy, BOOST a
+        successful one, START_NEW a lesson; CONTINUE/REDUCE are skipped. Best-
+        effort: a write failure must never break the decision loop.
+        """
+        category = self._ACTION_TO_CATEGORY.get(decision.action)
+        if category is None:
+            return
+        attack_type = decision.affected_attacks[0] if decision.affected_attacks else None
+        metadata = {
+            "action": decision.action.value,
+            "affected_attacks": decision.affected_attacks,
+            "success_criteria": decision.success_criteria,
+        }
+        try:
+            self.record_strategy(
+                category,
+                decision.reasoning,
+                attack_type=attack_type,
+                confidence=decision.confidence,
+                metadata=metadata,
+            )
+        except Exception as exc:  # noqa: BLE001 - learning capture must not break the loop
+            print(f"Warning: failed to record strategy from decision ({exc})")
+
     def _save_decision(self, decision: StrategicDecision):
         try:
             from kryptos.db import get_conn
+
             with get_conn() as conn:
                 cur = conn.cursor()
                 cur.execute(

--- a/src/kryptos/persistence.py
+++ b/src/kryptos/persistence.py
@@ -173,6 +173,71 @@ def fetch_top_candidates(limit: int = 20) -> list[dict[str, Any]]:
         return []
 
 
+_STRATEGY_CATEGORIES = ("successful", "failed", "lesson")
+
+
+def persist_strategy(
+    category: str,
+    description: str,
+    attack_type: str | None = None,
+    confidence: float | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> int | None:
+    """Record one accumulated-strategy entry in the ``strategy_kb`` table.
+
+    ``category`` must be one of ``successful``, ``failed``, or ``lesson`` (the
+    table's CHECK constraint). Returns the new ``strategy_kb.id``, or ``None``
+    if persistence was skipped (no DATABASE_URL) or failed — callers keep their
+    own JSONL/in-memory fallback, so a missing DB never loses the learning.
+    """
+    if category not in _STRATEGY_CATEGORIES:
+        raise ValueError(f"category must be one of {_STRATEGY_CATEGORIES}, got {category!r}")
+    if not db_enabled():
+        return None
+    try:
+        from kryptos.db import get_conn
+    except ImportError as exc:  # pragma: no cover - defensive
+        logger.warning("DB persistence unavailable (%s); skipping", exc)
+        return None
+
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO strategy_kb (category, description, attack_type, confidence, metadata)"
+                    " VALUES (%s, %s, %s, %s, %s::jsonb) RETURNING id",
+                    (category, description, attack_type, confidence, json.dumps(metadata or {})),
+                )
+                strategy_id = cur.fetchone()[0]
+        logger.info("Persisted %s strategy %s to strategy_kb", category, strategy_id)
+        return int(strategy_id)
+    except Exception as exc:  # noqa: BLE001 - persistence must never break a run
+        logger.warning("Failed to persist strategy to DB (%s); caller fallback unaffected", exc)
+        return None
+
+
+def fetch_strategy_kb(limit: int = 200) -> list[dict[str, Any]]:
+    """Return accumulated ``strategy_kb`` entries (newest first). Empty if DB off."""
+    if not db_enabled():
+        return []
+    try:
+        from kryptos.db import get_conn
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id, category, description, attack_type, confidence, metadata, created_at"
+                    " FROM strategy_kb ORDER BY id DESC LIMIT %s",
+                    (limit,),
+                )
+                rows = cur.fetchall()
+        cols = ["id", "category", "description", "attack_type", "confidence", "metadata", "created_at"]
+        return [dict(zip(cols, row)) for row in rows]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to fetch strategy_kb (%s)", exc)
+        return []
+
+
 def table_counts() -> dict[str, int]:
     """Return row counts for the kryptos tables. Empty dict if DB disabled."""
     if not db_enabled():
@@ -197,8 +262,10 @@ def table_counts() -> dict[str, int]:
 __all__ = [
     "db_enabled",
     "persist_campaign_candidates",
+    "persist_strategy",
     "fetch_recent_runs",
     "fetch_run_candidates",
     "fetch_top_candidates",
+    "fetch_strategy_kb",
     "table_counts",
 ]

--- a/tests/functional/test_strategy_kb_write.py
+++ b/tests/functional/test_strategy_kb_write.py
@@ -1,0 +1,178 @@
+"""Tests for the strategy_kb write path: persistence helper + director recording."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from kryptos import persistence
+from kryptos.agents.ops_director import OpsStrategicDirector, StrategicDecision, StrategyAction
+
+# --- persistence.persist_strategy ---------------------------------------------
+
+
+def test_persist_strategy_rejects_bad_category() -> None:
+    with pytest.raises(ValueError, match="category must be one of"):
+        persistence.persist_strategy("bogus", "desc")
+
+
+def test_persist_strategy_noop_without_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    assert persistence.persist_strategy("failed", "no db here") is None
+
+
+class _FakeCursor:
+    def __init__(self, sink: list[tuple]) -> None:
+        self._sink = sink
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql: str, params: tuple) -> None:
+        self._sink.append((sql, params))
+
+    def fetchone(self):
+        return (42,)
+
+
+class _FakeConn:
+    def __init__(self, sink: list[tuple]) -> None:
+        self._sink = sink
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def cursor(self):
+        return _FakeCursor(self._sink)
+
+
+def test_persist_strategy_writes_to_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+    sink: list[tuple] = []
+    import kryptos.db as db
+
+    monkeypatch.setattr(db, "get_conn", lambda: _FakeConn(sink))
+
+    sid = persistence.persist_strategy(
+        "successful",
+        "vigenere period 14 promising",
+        attack_type="vigenere",
+        confidence=0.8,
+        metadata={"k": "v"},
+    )
+    assert sid == 42
+    assert len(sink) == 1
+    sql, params = sink[0]
+    assert "INSERT INTO strategy_kb" in sql
+    assert params[0] == "successful"
+    assert params[1] == "vigenere period 14 promising"
+    assert params[2] == "vigenere"
+    assert params[3] == 0.8
+    assert json.loads(params[4]) == {"k": "v"}
+
+
+# --- OpsStrategicDirector.record_strategy -------------------------------------
+
+
+def _director(tmp_path: Path) -> OpsStrategicDirector:
+    return OpsStrategicDirector(llm_provider="local", model="rule-based", cache_dir=tmp_path / "ops")
+
+
+def test_record_strategy_rejects_bad_category(tmp_path: Path) -> None:
+    director = _director(tmp_path)
+    with pytest.raises(ValueError):
+        director.record_strategy("invalid", "x")
+
+
+def test_record_strategy_updates_memory_and_jsonl_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    director = _director(tmp_path)
+
+    director.record_strategy("failed", "hill 3x3 stagnant", attack_type="hill_3x3", confidence=0.6, metadata={"a": 1})
+
+    # In-memory KB reflects the entry immediately under the right list.
+    failed = director.strategy_kb["failed_strategies"]
+    assert failed[-1]["description"] == "hill 3x3 stagnant"
+    assert failed[-1]["attack_type"] == "hill_3x3"
+
+    # With no DB, it falls back to a JSONL file rather than losing the learning.
+    kb_file = director.cache_dir / "strategy_kb_writes.jsonl"
+    assert kb_file.exists()
+    row = json.loads(kb_file.read_text().splitlines()[-1])
+    assert row["category"] == "failed"
+    assert row["description"] == "hill 3x3 stagnant"
+
+
+def test_record_strategy_uses_db_and_skips_jsonl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    director = _director(tmp_path)
+    # DB write "succeeds" (returns an id) -> no JSONL fallback should be written.
+    monkeypatch.setattr(persistence, "persist_strategy", lambda *a, **k: 7)
+
+    director.record_strategy("successful", "promising", attack_type="vigenere", confidence=0.9)
+
+    assert director.strategy_kb["successful_strategies"][-1]["description"] == "promising"
+    assert not (director.cache_dir / "strategy_kb_writes.jsonl").exists()
+
+
+# --- _record_strategy_from_decision mapping -----------------------------------
+
+
+def _decision(action: StrategyAction) -> StrategicDecision:
+    return StrategicDecision(
+        timestamp=datetime.now(),
+        action=action,
+        reasoning=f"{action.value} reasoning",
+        affected_attacks=["attack_x"],
+        resource_changes={},
+        success_criteria="criteria",
+        review_in_hours=2.0,
+        confidence=0.75,
+    )
+
+
+@pytest.mark.parametrize(
+    "action,expected_list",
+    [
+        (StrategyAction.BOOST, "successful_strategies"),
+        (StrategyAction.START_NEW, "lessons_learned"),
+        (StrategyAction.PIVOT, "failed_strategies"),
+        (StrategyAction.STOP, "failed_strategies"),
+        (StrategyAction.EMERGENCY_STOP, "failed_strategies"),
+    ],
+)
+def test_decision_maps_to_kb_category(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, action: StrategyAction, expected_list: str
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    director = _director(tmp_path)
+    before = len(director.strategy_kb[expected_list])
+
+    director._record_strategy_from_decision(_decision(action))
+
+    entries = director.strategy_kb[expected_list]
+    assert len(entries) == before + 1
+    assert entries[-1]["attack_type"] == "attack_x"
+    assert entries[-1]["metadata"]["action"] == action.value
+
+
+@pytest.mark.parametrize("action", [StrategyAction.CONTINUE, StrategyAction.REDUCE])
+def test_steady_state_decisions_record_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, action: StrategyAction
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    director = _director(tmp_path)
+    sizes = {k: len(v) for k, v in director.strategy_kb.items()}
+
+    director._record_strategy_from_decision(_decision(action))
+
+    assert {k: len(v) for k, v in director.strategy_kb.items()} == sizes
+    assert not (director.cache_dir / "strategy_kb_writes.jsonl").exists()


### PR DESCRIPTION
- Added OpsStrategicDirector.record_strategy() to persist accumulated strategies to the strategy_kb table (Neon) with best-effort fallback to JSONL file
- Added _record_strategy_from_decision() to translate strategic decisions into durable KB entries (BOOST → successful, PIVOT/STOP → failed, START_NEW → lesson)
- Added fetch_strategy_kb() and persist_strategy() to persistence module to manage the KB durably across DB and fallback storage
- Comprehensive test suite covering category validation, DB write paths, fallback behavior, and decision-to-strategy mapping
- Steady-state decisions (CONTINUE/REDUCE) skip recording as expected

# Pull Request Template

## Summary

What changed and why it matters.

## Changes

- List the key changes in concise bullets.

## Testing

Describe validation steps and outcomes. Include exact commands or reproducible steps for affected areas.

## Manifesto Alignment

Explain alignment with core manifesto commitments:

- Signal improvement or risk reduction delivered by this change.
- Reproducibility path (deterministic commands, artifacts, provenance).
- Pruning decision: what weak path was removed, avoided, or explicitly left unchanged.

Checklist:

- [ ] Signal impact described (measured or expected)
- [ ] Reproducibility evidence included (commands/artifacts)
- [ ] Pruning/retirement note included (or explicit N/A rationale)

## Screenshots (optional)

Add before/after screenshots only when UI or visual outputs changed.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (if needed)
- [ ] Roadmap/tasks updated when strategic scope changed
- [ ] Related issues/tasks linked
- [ ] Follows project conventions and style guidelines
- [ ] Passes all automated checks (linting, tests, etc.)
