### PR TITLE
docs: mark strategy_kb write path and SSE log tail as done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # 🗺️ Kryptos Roadmap
 
-Last Updated: 2026-06-17
+Last Updated: 2026-06-20
 Next Review: 2026-07-01
 ---
 
@@ -30,15 +30,15 @@ Next Review: 2026-07-01
 
 > Stack shipped as specified: FastAPI + React SPA in a single multistage Docker container, served from `frontend/dist` by `create_app()`, backed by Neon. See `docs/analysis/K4-FRONTEND.md`.
 
-- [x] **Ops Center** — live campaign monitoring, agent status row, top fused candidates table, run history with drill-down, ad-hoc decrypt panel (#100). Live log tail via SSE is the remaining piece (see Phase 3).
+- [x] **Ops Center** — live campaign monitoring, agent status row, top fused candidates table, run history with drill-down, ad-hoc decrypt panel (#100). Live log tail via SSE shipped (#118 backend, #119 frontend).
 - [x] **K1–K3 Animated Decoder** — step-by-step visual explainer of how each solved section was encrypted and cracked (#102)
 - [x] **Database admin page** — Neon connection status + per-table row counts (#104)
 - [x] **Vault** — seal/unseal/peek encrypt/decrypt interface (keyed-alphabet Vigenère) with TTL and read-count enforcement (#115 backend, #116 frontend)
 - [ ] **K4 Attack Dashboard** — dedicated real-time pipeline-progress + evidence-artifact viewer (most is covered by Ops Center, Database, and RAG search; a standalone attack-vector fingerprint view remains)
 
 ### Phase 3 — API
-- [x] **REST dashboard API** — `/api/status`, `/api/runs`, `/api/runs/{id}/candidates`, `/api/candidates`, `POST /api/decrypt` (#99); turbovec RAG search at `/api/rag/*` (#113). `/api/stream/logs` (SSE) is in flight on a separate branch.
-- [ ] **`strategy_kb` write path** — automate writing successful/failed strategies from `OpsStrategicDirector` back to Neon
+- [x] **REST dashboard API** — `/api/status`, `/api/runs`, `/api/runs/{id}/candidates`, `/api/candidates`, `POST /api/decrypt` (#99); turbovec RAG search at `/api/rag/*` (#113); `GET /api/stream/logs` SSE live-log tail (#118).
+- [x] **`strategy_kb` write path** — `OpsStrategicDirector.record_strategy()` persists BOOST/PIVOT/STOP/START_NEW decisions to Neon `strategy_kb` table with JSONL fallback; `_record_strategy_from_decision()` auto-invoked on every `analyze()` cycle (#122).
 - [x] **Candidate & run storage** — `candidates` and `campaign_runs` tables in Neon, persisted best-effort from campaigns (#98)
 
 ### Phase 4 — Validation & hardening

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Last Updated: 2026-06-17
+Last Updated: 2026-06-20
 
 
 ## Todo
@@ -9,28 +9,20 @@ Last Updated: 2026-06-17
 
 ### Phase 1: Dashboard & UI
 - Develop dedicated K4 Attack Dashboard: visual fingerprint map of attack vectors plausible vs. covered vs. unknown (Ops Center, Database, and RAG search already cover live progress, scoring, and artifact lookup)
-- Wire the SSE live-log tail (`/api/stream/logs`) into the Ops Center page (backend in flight on a separate branch)
 
-### Phase 2: Data & API
-- `strategy_kb` write path — automate persisting successful/failed strategies from `OpsStrategicDirector` back to Neon
-
-### Phase 3: Post-Solution Analysis
+### Phase 2: Post-Solution Analysis
 - Analyze and document attack path, key insights, and lessons learned after solution
 - Write comprehensive report on solution narrative and cryptanalytic implications
 - Update README and documentation to reflect solution and research outcomes
 
-### Phase 4: Misc/Supporting
+### Phase 3: Misc/Supporting
 - Update docs/analysis/K4-FRONTEND.md for frontend/dashboard integration
 - Ensure all new features have test coverage and artifact logging
 
 
-## In Progress
-
-- [ ] **SSE live-log tail** — `GET /api/stream/logs` (StreamingResponse, `text/event-stream`) backed by a thread-safe ring buffer fed by a `kryptos`-logger handler, plus a frontend `LogTail` EventSource component on Ops Center. Backend implemented and unit-tested on the `sse-log-tail` branch.
-
 ## Done
 
-### Dashboard, REST API & Web UI (Q1 2027 Phases 1–2)
+### Dashboard, REST API, Web UI & Ops Strategy KB (Q1 2027 Phases 1–3)
 
 - [x] **FastAPI dashboard endpoints** — `/api/status`, `/api/runs`, `/api/runs/{id}/candidates`, `/api/candidates`, `POST /api/decrypt` over the `create_app()` factory (#99).
 - [x] **Neon persistence for campaigns** — `campaign_runs` + `candidates` tables (`db_schema.py`) with best-effort write path from live campaigns (#93 schema/`kryptos db-init`, #98 persistence).
@@ -38,6 +30,8 @@ Last Updated: 2026-06-17
 - [x] **Kryptos Vault** — seal/unseal/peek API + `vault_payloads` table; keyed-alphabet Vigenère with TTL and read-count enforcement, key never stored, wrong-key attempts don't burn a read (#115 backend, #116 frontend).
 - [x] **Single-container delivery** — FastAPI serves the built SPA from `frontend/dist` via `StaticFiles(html=True)`; root `Dockerfile` builds the bundle in a `node:22-alpine` stage and ships it with the API (#114).
 - [x] **turbovec RAG behind the FastAPI app** — `/api/rag/*` semantic search over `artifacts/` embedded into the dashboard service (#113, #87).
+- [x] **SSE live-log tail** — `GET /api/stream/logs` (StreamingResponse, `text/event-stream`) backed by a thread-safe ring buffer fed by a `kryptos`-logger handler (#118); `LogTail` EventSource component on Ops Center page (#119).
+- [x] **`strategy_kb` write path** — `OpsStrategicDirector.record_strategy()` + `_record_strategy_from_decision()` persist BOOST/PIVOT/STOP/START_NEW decisions to Neon `strategy_kb` with JSONL fallback; `fetch_strategy_kb()` and `persist_strategy()` added to `kryptos.persistence` (#122).
 
 ### SA transposition seeding + early-crib locking verification
 


### PR DESCRIPTION
## Summary

- **ROADMAP.md**: `strategy_kb` write path marked `[x]` with implementation detail (#122); REST API entry updated to reference SSE PRs #118/#119 (was "in flight on a separate branch"); Ops Center note corrected; date bumped to 2026-06-20.
- **TASKS.md**: `strategy_kb` write path and SSE live-log tail moved from Todo/In Progress into Done under the Dashboard/API section; redundant phase numbering cleaned up; Done section header updated to reflect all three phases shipped.

Both items shipped via PRs that landed before this doc pass — this is the reconciliation.

## Test plan
- [ ] Confirm ROADMAP Phase 3 has no remaining `[ ]` items except the K4 Attack Dashboard and post-solution docs
- [ ] Confirm TASKS.md In Progress section is empty (removed — nothing currently in-flight)
- [ ] Confirm strategy_kb and SSE entries appear in Done with correct PR refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)